### PR TITLE
[SECURITY] Apply xmldom override in Electron lockfile

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -870,9 +870,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## What

PR #10 declared \`"@xmldom/xmldom": "^0.8.13"\` in \`electron/package.json\` overrides but \`electron/package-lock.json\` was never regenerated. The transitive dep via \`plist\` (from electron-builder) was still pinned to **0.8.12** — vulnerable.

This PR regenerates \`electron/package-lock.json\` so the override actually applies.

## Why

Three open Dependabot alerts are all blocked on this lockfile:

| Alert | CVE | Summary |
|---|---|---|
| #27 | CVE-2026-41675 | XML node injection through unvalidated processing instruction serialization |
| #28 | CVE-2026-41672 | XML node injection through unvalidated comment serialization |
| #30 | CVE-2026-41674 | XML injection through unvalidated DocumentType serialization |

All three patched in 0.8.13.

## Change surface

One file. Three lines. Only the version, URL, and integrity hash for \`@xmldom/xmldom\`.

\`\`\`diff
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
\`\`\`

## Verification

- Before: \`electron/package-lock.json\` had \`@xmldom/xmldom@0.8.12\`
- \`cd electron && npm install\`
- After: \`electron/package-lock.json\` has \`@xmldom/xmldom@0.8.13\`
- \`npm install\` exits clean, \`audited 379 packages\`, \`0 vulnerabilities\`
- No other files changed

## Expected outcome

Merging clears Dependabot #27, #28, #30.