### PR TITLE
[SECURITY] Close /api/command/tool/run bypass

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -19,7 +19,7 @@ import { ConstitutionalLayer } from './constitutional';
 import { AgentStateEngine } from './spark-soul';
 import { UserProfile } from './user-profile';
 import { validateToolArgs, repairToolCallMessages } from './agent/message-repair';
-import { PreparedCall, ToolExecutorDeps, executeToolBatch, TOOL_TYPE_MAP } from './agent/tool-executor';
+import { PreparedCall, ToolExecutorDeps, executeToolBatch, executeSingleTool, TOOL_TYPE_MAP } from './agent/tool-executor';
 import { buildSystemPrompt } from './agent/prompt-builder';
 import { ExecutionAuditor } from './execution-auditor';
 import { CrossSessionLearning } from './cross-session';
@@ -474,136 +474,48 @@ export class Agent {
 
       for (const tc of toolCalls) {
         const toolName = tc.function.name;
-        const tool = this.tools.get(toolName);
 
-        if (!tool) {
-          prepared.push({
-            tc,
-            tool: null as unknown as Tool,
-            args: {},
-            denied: false,
-            error: `Error: Unknown tool "${toolName}"`,
-          });
-          continue;
-        }
-
-        // Policy check: is this tool allowed?
-        const policyCheck = this.policyEnforcer.isToolAllowed(toolName);
-        if (!policyCheck.allowed) {
-          this.auditLogger.log({ tool: toolName, action: 'policy_block', args: {}, reason: policyCheck.reason });
-          prepared.push({ tc, tool, args: {}, denied: false, error: `Error: ${policyCheck.reason}` });
-          continue;
-        }
-
+        // Parse JSON args up front — LLM-produced tool calls carry args as
+        // a JSON string; _prepareToolCall expects an object.
         let args: Record<string, unknown>;
         try {
           args = JSON.parse(tc.function.arguments);
         } catch {
-          prepared.push({ tc, tool, args: {}, denied: false, error: `Error: Invalid JSON arguments for ${toolName}` });
+          const tool = this.tools.get(toolName);
+          prepared.push({
+            tc,
+            tool: (tool || null) as unknown as Tool,
+            args: {},
+            denied: false,
+            error: `Error: Invalid JSON arguments for ${toolName}`,
+          });
           continue;
         }
 
-        // Arg validation against schema
-        const validationError = validateToolArgs(args, tool.parameters);
-        if (validationError) {
-          prepared.push({ tc, tool, args, denied: false, error: `Error: ${validationError} for ${toolName}` });
-          continue;
+        const { prepared: p, riskAssessment } = await this._prepareToolCall(
+          toolName,
+          args,
+          { interactivePrompt: true },
+        );
+        // Preserve the LLM-provided tool_call id so the downstream
+        // tool-result message carries the correct tool_call_id for the
+        // provider round-trip.
+        p.tc = tc;
+
+        // Yield a tool_call event only when the gate chain got as far as
+        // computing a risk score — i.e. the tool exists, policy allowed
+        // it, and args validated. Earlier bailouts (unknown tool, policy
+        // block, schema error) go straight to a tool_result error, same
+        // as before this refactor.
+        if (riskAssessment) {
+          yield {
+            type: 'tool_call',
+            toolCall: { name: toolName, args },
+            risk: { score: riskAssessment.score, level: riskAssessment.level },
+          };
         }
 
-        // Compute risk score before execution
-        const policyPermission = this.policyEnforcer.getToolPermission(toolName);
-        let effectivePermission = policyPermission || tool.permission;
-        const riskAssessment = this.riskScorer.assess(toolName, args, effectivePermission);
-        yield {
-          type: 'tool_call',
-          toolCall: { name: toolName, args },
-          risk: { score: riskAssessment.score, level: riskAssessment.level },
-        };
-
-        // Log risk breakdown for high-risk calls
-        if (riskAssessment.score > 50) {
-          const breakdown = riskAssessment.factors.map((f) => `${f.name}=${f.rawScore}`).join(', ');
-          this.auditLogger.log({
-            tool: toolName,
-            action: 'execute',
-            args,
-            result: `risk:${riskAssessment.score}`,
-            reason: breakdown,
-          });
-        }
-
-        // Constitutional safety check (CORD + VIGIL)
-        // Retry prevention: if the same tool+args were already blocked, deny immediately
-        const blockKey = `${toolName}:${JSON.stringify(args)}`;
-        if (this.cordBlockedKeys.has(blockKey)) {
-          prepared.push({ tc, tool, args, denied: true, error: 'Blocked by safety policy.' });
-          continue;
-        }
-        if (this.constitutional) {
-          const cordResult = this.constitutional.evaluateAction({
-            tool: toolName,
-            args,
-            type: TOOL_TYPE_MAP[toolName] || 'unknown',
-          });
-
-          if (cordResult.decision === 'BLOCK') {
-            this.trackCordBlock(blockKey);
-            this.auditLogger.log({
-              tool: toolName,
-              action: 'constitutional_block',
-              args,
-              reason: cordResult.explanation || 'Constitutional violation',
-            });
-            this.metricsCollector.increment('security_blocks_total', { tool: toolName, type: 'constitutional' });
-            prepared.push({ tc, tool, args, denied: true, error: `Blocked by safety policy.` });
-            continue;
-          }
-
-          if (cordResult.decision === 'CHALLENGE') {
-            effectivePermission = 'always-ask';
-          }
-        }
-
-        // SPARK adaptive safety — learned judgment overrides autoApprove
-        let sparkChallenged = false;
-        if (this.stateEngine) {
-          try {
-            const sparkResult = this.stateEngine.evaluateTool(toolName, args);
-            if (sparkResult.decision === 'BLOCK') {
-              prepared.push({ tc, tool, args, denied: false, error: 'Error: Blocked by SPARK: ' + sparkResult.reason });
-              continue;
-            }
-            if (sparkResult.decision === 'CHALLENGE') {
-              effectivePermission = 'always-ask';
-              sparkChallenged = true;
-            }
-          } catch (e) {
-            log.warn(`[CodeBot] Failed to initialize state engine: ${(e as Error).message}`);
-          }
-        }
-
-        // Permission check: policy override > tool default
-        // autoApprove bypasses ALL permission levels (autonomous/dashboard mode)
-        // EXCEPTION: SPARK's learned CHALLENGE overrides autoApprove — the system
-        // has learned from repeated failures that this category needs human review
-        const needsPermission =
-          sparkChallenged ||
-          (!this.autoApprove && (effectivePermission === 'always-ask' || effectivePermission === 'prompt'));
-
-        let denied = false;
-        if (needsPermission) {
-          const approved = await this.askPermission(toolName, args, riskAssessment, {
-            sandbox: this.policyEnforcer.getSandboxMode() === 'docker',
-            network: this.policyEnforcer.isNetworkAllowed(),
-          });
-          if (!approved) {
-            denied = true;
-            this.auditLogger.log({ tool: toolName, action: 'deny', args, reason: 'User denied permission' });
-            this.metricsCollector.increment('permission_denials_total', { tool: toolName });
-          }
-        }
-
-        prepared.push({ tc, tool, args, denied });
+        prepared.push(p);
       }
 
       // ── Phase 2: Execute tools (parallel where possible) ──
@@ -708,6 +620,254 @@ export class Agent {
   /** Get the token tracker for session summary / CLI display */
   getTokenTracker(): TokenTracker {
     return this.tokenTracker;
+  }
+
+  /**
+   * Validate + gate a single tool call through the full security chain:
+   *   schema validation → policy allow-list → risk scoring → CORD
+   *   (constitutional) → SPARK → permission.
+   *
+   * Returns a PreparedCall (with `denied` or `error` set when blocked) and
+   * the RiskAssessment (or null if we bailed before scoring — unknown
+   * tool, policy block, schema error). Audit entries for policy /
+   * constitutional / permission denials are written before return.
+   *
+   * Shared by the agent loop (`run()` Phase 1) and public `runSingleTool`
+   * so dashboard / IPC / script callers replay the exact same gates as
+   * autonomous-loop tool calls. Before 2026-04-23 the dashboard tool
+   * runner called `tool.execute(args)` directly on the registry entry,
+   * skipping this chain entirely — that bypass is what `runSingleTool`
+   * closes.
+   *
+   * @param opts.interactivePrompt — when false, tools that would require
+   *   a permission prompt (`always-ask` / `prompt` / SPARK challenge)
+   *   are auto-denied (fail-closed). Dashboard HTTP callers must pass
+   *   false because there is no user to prompt over the wire.
+   */
+  private async _prepareToolCall(
+    toolName: string,
+    args: Record<string, unknown>,
+    opts: { interactivePrompt: boolean },
+  ): Promise<{ prepared: PreparedCall; riskAssessment: RiskAssessment | null }> {
+    const tc: ToolCall = {
+      id: `call_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`,
+      type: 'function',
+      function: { name: toolName, arguments: JSON.stringify(args) },
+    };
+
+    const tool = this.tools.get(toolName);
+    if (!tool) {
+      return {
+        prepared: {
+          tc,
+          tool: null as unknown as Tool,
+          args,
+          denied: false,
+          error: `Error: Unknown tool "${toolName}"`,
+        },
+        riskAssessment: null,
+      };
+    }
+
+    // Policy allow-list
+    const policyCheck = this.policyEnforcer.isToolAllowed(toolName);
+    if (!policyCheck.allowed) {
+      this.auditLogger.log({ tool: toolName, action: 'policy_block', args, reason: policyCheck.reason });
+      return {
+        prepared: { tc, tool, args, denied: false, error: `Error: ${policyCheck.reason}` },
+        riskAssessment: null,
+      };
+    }
+
+    // Schema validation
+    const validationError = validateToolArgs(args, tool.parameters);
+    if (validationError) {
+      return {
+        prepared: { tc, tool, args, denied: false, error: `Error: ${validationError} for ${toolName}` },
+        riskAssessment: null,
+      };
+    }
+
+    // Risk scoring
+    const policyPermission = this.policyEnforcer.getToolPermission(toolName);
+    let effectivePermission = policyPermission || tool.permission;
+    const riskAssessment = this.riskScorer.assess(toolName, args, effectivePermission);
+
+    if (riskAssessment.score > 50) {
+      const breakdown = riskAssessment.factors.map((f) => `${f.name}=${f.rawScore}`).join(', ');
+      this.auditLogger.log({
+        tool: toolName,
+        action: 'execute',
+        args,
+        result: `risk:${riskAssessment.score}`,
+        reason: breakdown,
+      });
+    }
+
+    // CORD retry prevention — previously blocked tool+args combo denies
+    // immediately without re-invoking the constitutional layer.
+    const blockKey = `${toolName}:${JSON.stringify(args)}`;
+    if (this.cordBlockedKeys.has(blockKey)) {
+      return {
+        prepared: { tc, tool, args, denied: true, error: 'Blocked by safety policy.' },
+        riskAssessment,
+      };
+    }
+
+    // Constitutional (CORD + VIGIL)
+    if (this.constitutional) {
+      const cordResult = this.constitutional.evaluateAction({
+        tool: toolName,
+        args,
+        type: TOOL_TYPE_MAP[toolName] || 'unknown',
+      });
+
+      if (cordResult.decision === 'BLOCK') {
+        this.trackCordBlock(blockKey);
+        this.auditLogger.log({
+          tool: toolName,
+          action: 'constitutional_block',
+          args,
+          reason: cordResult.explanation || 'Constitutional violation',
+        });
+        this.metricsCollector.increment('security_blocks_total', { tool: toolName, type: 'constitutional' });
+        return {
+          prepared: { tc, tool, args, denied: true, error: 'Blocked by safety policy.' },
+          riskAssessment,
+        };
+      }
+
+      if (cordResult.decision === 'CHALLENGE') {
+        effectivePermission = 'always-ask';
+      }
+    }
+
+    // SPARK adaptive safety — learned judgment overrides autoApprove
+    let sparkChallenged = false;
+    if (this.stateEngine) {
+      try {
+        const sparkResult = this.stateEngine.evaluateTool(toolName, args);
+        if (sparkResult.decision === 'BLOCK') {
+          return {
+            prepared: { tc, tool, args, denied: false, error: 'Error: Blocked by SPARK: ' + sparkResult.reason },
+            riskAssessment,
+          };
+        }
+        if (sparkResult.decision === 'CHALLENGE') {
+          effectivePermission = 'always-ask';
+          sparkChallenged = true;
+        }
+      } catch (e) {
+        log.warn(`[CodeBot] Failed to initialize state engine: ${(e as Error).message}`);
+      }
+    }
+
+    // Permission: policy override > tool default.
+    // autoApprove bypasses `always-ask`/`prompt` EXCEPT when SPARK
+    // raised a CHALLENGE (learned override).
+    const needsPermission =
+      sparkChallenged ||
+      (!this.autoApprove && (effectivePermission === 'always-ask' || effectivePermission === 'prompt'));
+
+    let denied = false;
+    if (needsPermission) {
+      if (!opts.interactivePrompt) {
+        // Non-interactive caller (dashboard HTTP, IPC, scripts) — fail
+        // closed instead of trying to prompt a user that isn't there.
+        this.auditLogger.log({
+          tool: toolName,
+          action: 'deny',
+          args,
+          reason: 'Non-interactive caller; tool requires permission prompt',
+        });
+        this.metricsCollector.increment('permission_denials_total', { tool: toolName });
+        denied = true;
+      } else {
+        const approved = await this.askPermission(toolName, args, riskAssessment, {
+          sandbox: this.policyEnforcer.getSandboxMode() === 'docker',
+          network: this.policyEnforcer.isNetworkAllowed(),
+        });
+        if (!approved) {
+          denied = true;
+          this.auditLogger.log({ tool: toolName, action: 'deny', args, reason: 'User denied permission' });
+          this.metricsCollector.increment('permission_denials_total', { tool: toolName });
+        }
+      }
+    }
+
+    return { prepared: { tc, tool, args, denied }, riskAssessment };
+  }
+
+  /**
+   * Public single-tool entry point for non-LLM callers (dashboard HTTP,
+   * IPC, scripts). Replays the full security chain — schema, policy,
+   * risk, CORD, SPARK, permission, audit — then executes the tool and
+   * returns the result.
+   *
+   * Dashboard tool-runner callsites must route through this method
+   * instead of `agent.getToolRegistry().get(name).execute(args)` — the
+   * latter completely skips the gate chain and was the bypass fixed in
+   * the 2026-04-23 security work.
+   *
+   * @param opts.interactivePrompt — defaults to false. Callers that can
+   *   block for an async user prompt may set this true; dashboard HTTP
+   *   should leave it false so always-ask tools fail closed.
+   */
+  async runSingleTool(
+    toolName: string,
+    args: Record<string, unknown>,
+    opts: { interactivePrompt?: boolean } = {},
+  ): Promise<{
+    result: string;
+    is_error: boolean;
+    blocked: boolean;
+    reason?: string;
+    durationMs?: number;
+  }> {
+    const { prepared } = await this._prepareToolCall(
+      toolName,
+      args ?? {},
+      { interactivePrompt: opts.interactivePrompt ?? false },
+    );
+
+    if (prepared.error) {
+      return {
+        result: prepared.error,
+        is_error: true,
+        blocked: prepared.denied,
+        reason: prepared.error,
+      };
+    }
+    if (prepared.denied) {
+      return {
+        result: 'Error: Blocked by safety policy.',
+        is_error: true,
+        blocked: true,
+        reason: 'Denied by policy / CORD / SPARK / permission gate',
+      };
+    }
+
+    const deps: ToolExecutorDeps = {
+      cache: this.cache,
+      rateLimiter: this.rateLimiter,
+      metricsCollector: this.metricsCollector,
+      auditLogger: this.auditLogger,
+      tokenTracker: this.tokenTracker,
+      stateEngine: this.stateEngine,
+      lastExecutedTools: this.lastExecutedTools,
+      ensureBranch: () => this.ensureBranch(),
+      checkToolCapabilities: (t, a) => this.checkToolCapabilities(t, a),
+      experientialMemory: this.experientialMemory,
+      currentTask: this.sessionGoal,
+    };
+
+    const output = await executeSingleTool(prepared, deps);
+    return {
+      result: output.content,
+      is_error: !!output.is_error,
+      blocked: false,
+      durationMs: output.durationMs,
+    };
   }
 
   /** Get the policy enforcer for inspection */

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -185,10 +185,25 @@ export class Agent {
       const { loadSkills, skillToTool } = require('./skills');
       const skills = loadSkills();
       for (const skill of skills) {
-        const toolExec = async (name: string, args: Record<string, unknown>) => {
-          const t = this.tools.get(name);
-          if (!t) return `Error: tool "${name}" not found`;
-          return t.execute(args);
+        // SECURITY — skill inner steps MUST replay the full gate chain.
+        //
+        // The original callback called `t.execute(args)` directly, which
+        // meant a skill step running `execute`, `write_file`, `app`, etc.
+        // bypassed schema validation, policy, risk, CORD, SPARK,
+        // capability check, permission, and audit — a variant of the
+        // same bypass POST /api/command/tool/run had. Any skill shipped
+        // or user-defined could be a back-door to those layers.
+        //
+        // Routing through `runSingleTool` applies the same gates every
+        // other tool call goes through. `interactivePrompt: true`
+        // matches the agent-loop execution context (REPL readline or
+        // dashboard-injected permission UI); the HTTP endpoint blocks
+        // `skill_*` at the outer gate (see src/dashboard/command-api.ts)
+        // so no HTTP request ever reaches this callback.
+        const toolExec = async (name: string, args: Record<string, unknown>): Promise<string> => {
+          if (!this.tools.get(name)) return `Error: tool "${name}" not found`;
+          const outcome = await this.runSingleTool(name, args, { interactivePrompt: true });
+          return outcome.result;
         };
         this.tools.register(skillToTool(skill, toolExec));
       }

--- a/src/dashboard/command-api.ts
+++ b/src/dashboard/command-api.ts
@@ -170,6 +170,22 @@ export function registerCommandRoutes(
   });
 
   // ── POST /api/command/tool/run ──
+  //
+  // SECURITY — do NOT call `tool.execute(body.args)` directly here.
+  //
+  // Before 2026-04-23 this route invoked the tool registry entry straight
+  // from HTTP, bypassing schema validation, policy allow-list, risk
+  // scoring, ConstitutionalLayer (CORD + VIGIL), SPARK, permission
+  // prompts, and AuditLogger. A dashboard token holder (or a compromised
+  // local process able to read the token) could drive any registered
+  // tool — `execute`, `write_file`, `docker`, `ssh_remote`, `delegate` —
+  // with zero CORD decisions and zero audit entries.
+  //
+  // Agent.runSingleTool() replays the exact same gate chain that the
+  // autonomous agent loop (src/agent.ts Phase 1) applies to LLM-proposed
+  // tool calls. `interactivePrompt: false` makes always-ask / prompt
+  // tools fail closed over HTTP — there is no user on the wire to
+  // answer a readline prompt.
   server.route('POST', '/api/command/tool/run', async (req, res) => {
     if (!agent) {
       DashboardServer.error(res, 503, 'Agent not available');
@@ -189,27 +205,25 @@ export function registerCommandRoutes(
       return;
     }
 
-    const tool = agent.getToolRegistry().get(body.tool);
-    if (!tool) {
+    // Fast 404 for unknown tools so the response shape stays aligned
+    // with the pre-fix behavior for that one case (dashboard UI relies on
+    // a 404 to show "tool not found" rather than a 200-with-error-body).
+    if (!agent.getToolRegistry().get(body.tool)) {
       DashboardServer.error(res, 404, `Tool "${body.tool}" not found`);
       return;
     }
 
     const startMs = Date.now();
-    try {
-      const result = await tool.execute(body.args || {});
-      DashboardServer.json(res, {
-        result,
-        is_error: typeof result === 'string' && result.startsWith('Error:'),
-        duration_ms: Date.now() - startMs,
-      });
-    } catch (err: unknown) {
-      DashboardServer.json(res, {
-        result: err instanceof Error ? err.message : String(err),
-        is_error: true,
-        duration_ms: Date.now() - startMs,
-      });
-    }
+    const outcome = await agent.runSingleTool(body.tool, body.args || {}, {
+      interactivePrompt: false,
+    });
+    DashboardServer.json(res, {
+      result: outcome.result,
+      is_error: outcome.is_error,
+      blocked: outcome.blocked,
+      reason: outcome.reason,
+      duration_ms: Date.now() - startMs,
+    });
   });
 
   // ── GET /api/command/agent-status (SSE) ──

--- a/src/dashboard/command-api.ts
+++ b/src/dashboard/command-api.ts
@@ -213,6 +213,36 @@ export function registerCommandRoutes(
       return;
     }
 
+    // SECURITY — skill_* tools are composite: their `execute()` runs a
+    // pipeline of inner tool calls (execute / write_file / app / etc.).
+    // Even though those inner steps are now routed through runSingleTool
+    // in agent.ts (the gate chain replays for every step), we still
+    // refuse skill invocations on this endpoint:
+    //
+    // 1. The inner-step callback is wired with `interactivePrompt: true`
+    //    to match the autonomous-loop context (REPL / dashboard
+    //    permission UI). If an HTTP caller reaches it, any inner step
+    //    that needs a prompt would invoke askPermission — which on an
+    //    HTTP-request thread with no UI attached would fail closed at
+    //    best and hang the request at worst.
+    // 2. Defense in depth: the dashboard UI has its own skill launcher
+    //    (with an explicit plan + confirmation step) that does NOT go
+    //    through this endpoint. A generic token-holder driving
+    //    skill_* through this route is an attack shape, not a
+    //    legitimate UX.
+    //
+    // If a future dashboard surface genuinely needs to drive skills
+    // over HTTP, add a dedicated endpoint that does step-by-step
+    // confirmation; do not lift this guard.
+    if (body.tool.startsWith('skill_')) {
+      DashboardServer.error(
+        res,
+        403,
+        'Skill tools must be invoked via the skill launcher, not the generic tool runner.',
+      );
+      return;
+    }
+
     const startMs = Date.now();
     const outcome = await agent.runSingleTool(body.tool, body.args || {}, {
       interactivePrompt: false,

--- a/src/dashboard/tool-run-bypass.test.ts
+++ b/src/dashboard/tool-run-bypass.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, afterEach } from 'node:test';
+import * as assert from 'node:assert';
+import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { DashboardServer } from './server';
+import { registerCommandRoutes } from './command-api';
+import { Agent } from '../agent';
+import type { LLMProvider, AgentEvent } from '../types';
+
+/**
+ * Acceptance tests for the POST /api/command/tool/run bypass fix
+ * (2026-04-23 SECURITY).
+ *
+ * Before this fix the endpoint called `tool.execute(body.args)` directly
+ * on the ToolRegistry entry — bypassing schema validation, policy
+ * allow-list, risk scoring, ConstitutionalLayer, SPARK, permission
+ * prompts, and AuditLogger. A dashboard-token holder could run any
+ * registered tool with zero security gates and zero audit trail.
+ *
+ * These tests prove:
+ *   1. A call that requires a permission prompt (e.g. `execute`, whose
+ *      default permission is `prompt`) is denied with `blocked: true`
+ *      and a matching audit entry is written — there's no user on an
+ *      HTTP wire to answer a readline prompt, so we fail closed.
+ *   2. An `auto`-permission tool (e.g. `read_file`) still runs through
+ *      the endpoint successfully, so the fix doesn't break the legit
+ *      dashboard UX.
+ */
+
+function request(
+  url: string,
+  method: string,
+  token: string,
+  body?: unknown,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+    if (body !== undefined) headers['Content-Type'] = 'application/json';
+    const req = http.request(url, { method, headers }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => resolve({
+        status: res.statusCode || 0,
+        body: Buffer.concat(chunks).toString('utf-8'),
+      }));
+    });
+    req.on('error', reject);
+    if (body !== undefined) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+function makeStubProvider(): LLMProvider {
+  return {
+    name: 'stub',
+    async *chat(): AsyncGenerator<AgentEvent> {
+      yield { type: 'done' };
+    },
+  } as LLMProvider;
+}
+
+let portCounter = 15620;
+function nextPort(): number { return portCounter++; }
+
+describe('POST /api/command/tool/run — security gate chain', () => {
+  let server: DashboardServer | null = null;
+  let agent: Agent | null = null;
+  let fixtureDir: string | null = null;
+
+  afterEach(async () => {
+    if (server && server.isRunning()) await server.stop();
+    server = null;
+    if (fixtureDir && fs.existsSync(fixtureDir)) {
+      try { fs.rmSync(fixtureDir, { recursive: true }); } catch { /* ignore */ }
+    }
+    fixtureDir = null;
+    agent = null;
+  });
+
+  async function startServer(): Promise<{ port: number; token: string }> {
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-test-tool-run-'));
+    // A readable fixture file for the read_file happy-path test
+    fs.writeFileSync(path.join(fixtureDir, 'hello.txt'), 'hello from fixture\n');
+
+    // Match real dashboard usage: autoApprove=true. CORD issues CHALLENGE
+    // for almost every action by design (it wants a human on the prompt),
+    // so without autoApprove the dashboard would fail-closed on harmless
+    // tools too. autoApprove skips the permission gate for CHALLENGE but
+    // NOT for CORD BLOCK / SPARK CHALLENGE / policy / capability — the
+    // layers this test actually cares about.
+    agent = new Agent({
+      provider: makeStubProvider(),
+      model: 'stub-model',
+      providerName: 'stub',
+      projectRoot: fixtureDir,
+      autoApprove: true,
+    });
+
+    const port = nextPort();
+    server = new DashboardServer({ port });
+    registerCommandRoutes(server, agent);
+    await server.start();
+    return { port, token: server.getAuthToken() };
+  }
+
+  it('blocks a dangerous `execute` call and writes an audit entry', async () => {
+    const { port, token } = await startServer();
+    const sessionId = agent!.getAuditLogger().getSessionId();
+
+    const res = await request(
+      `http://127.0.0.1:${port}/api/command/tool/run`,
+      'POST',
+      token,
+      { tool: 'execute', args: { command: 'rm -rf /' } },
+    );
+
+    // Endpoint responds 200 with structured block outcome — NOT 500,
+    // NOT a successful execution.
+    assert.strictEqual(res.status, 200, `expected 200, got ${res.status}: ${res.body}`);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.is_error, true, `expected is_error: true, got body=${JSON.stringify(body)}`);
+    assert.strictEqual(body.blocked, true, `expected blocked: true, got body=${JSON.stringify(body)}`);
+    // Result should be the safety-policy message, not shell output.
+    assert.ok(
+      /blocked|policy|permission/i.test(String(body.result)),
+      `expected block message in result, got: ${body.result}`,
+    );
+
+    // An audit entry MUST exist for this session tagged with a
+    // deny/block action. This is the whole point of the fix — the old
+    // code path wrote nothing.
+    const entries = agent!.getAuditLogger().query({ sessionId });
+    const blockEntries = entries.filter(e =>
+      e.tool === 'execute' &&
+      (e.action === 'deny' ||
+       e.action === 'constitutional_block' ||
+       e.action === 'policy_block' ||
+       e.action === 'security_block'),
+    );
+    assert.ok(
+      blockEntries.length > 0,
+      `expected ≥1 block audit entry for execute, got entries=${JSON.stringify(entries.map(e => ({ tool: e.tool, action: e.action })))}`,
+    );
+  });
+
+  it('allows a safe `read_file` call to pass through', async () => {
+    const { port, token } = await startServer();
+
+    const target = path.join(fixtureDir!, 'hello.txt');
+    const res = await request(
+      `http://127.0.0.1:${port}/api/command/tool/run`,
+      'POST',
+      token,
+      { tool: 'read_file', args: { path: target } },
+    );
+
+    assert.strictEqual(res.status, 200, `expected 200, got ${res.status}: ${res.body}`);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(
+      body.blocked,
+      false,
+      `expected blocked: false for read_file, got body=${JSON.stringify(body)}`,
+    );
+    assert.strictEqual(
+      body.is_error,
+      false,
+      `expected is_error: false for read_file, got body=${JSON.stringify(body)}`,
+    );
+    assert.ok(
+      String(body.result).includes('hello from fixture'),
+      `expected file contents in result, got: ${body.result}`,
+    );
+  });
+
+  it('returns 404 for an unknown tool (preserves pre-fix shape)', async () => {
+    const { port, token } = await startServer();
+    const res = await request(
+      `http://127.0.0.1:${port}/api/command/tool/run`,
+      'POST',
+      token,
+      { tool: 'no_such_tool_exists', args: {} },
+    );
+    assert.strictEqual(res.status, 404, `expected 404, got ${res.status}: ${res.body}`);
+  });
+});

--- a/src/dashboard/tool-run-bypass.test.ts
+++ b/src/dashboard/tool-run-bypass.test.ts
@@ -184,4 +184,125 @@ describe('POST /api/command/tool/run — security gate chain', () => {
     );
     assert.strictEqual(res.status, 404, `expected 404, got ${res.status}: ${res.body}`);
   });
+
+  // ── Skill bypass (reviewer-flagged P1) ──
+  //
+  // Skill tools are composite: their `execute()` runs a pipeline of
+  // inner tool calls. Before this patch the inner-step callback called
+  // `t.execute(args)` directly, so a skill step running `execute`,
+  // `write_file`, etc. bypassed every gate on that inner step — a
+  // variant of the same bypass as the outer endpoint.
+  //
+  // Two layers close this: (a) block skill_* on the HTTP endpoint, (b)
+  // route the inner-step callback through runSingleTool so the gate
+  // chain replays for every step when invoked autonomously.
+
+  it('rejects skill_* invocations with 403 on /api/command/tool/run', async () => {
+    const { port, token } = await startServer();
+    // `standup-summary` is a built-in skill, always registered.
+    const toolName = 'skill_standup-summary';
+    assert.ok(
+      agent!.getToolRegistry().get(toolName),
+      'expected skill_standup-summary to be registered (built-in)',
+    );
+
+    const res = await request(
+      `http://127.0.0.1:${port}/api/command/tool/run`,
+      'POST',
+      token,
+      { tool: toolName, args: { channel: '#test' } },
+    );
+    assert.strictEqual(res.status, 403, `expected 403, got ${res.status}: ${res.body}`);
+    assert.match(
+      res.body,
+      /skill/i,
+      `expected error body to mention skills, got: ${res.body}`,
+    );
+  });
+
+  it('skill inner steps replay the gate chain — each step writes an audit entry', async () => {
+    // Isolate the CodeBot home so we can drop a fixture skill without
+    // touching the user's ~/.codebot/skills. Must be set BEFORE the
+    // Agent is constructed, because loadSkills() fires in the
+    // constructor.
+    const origHome = process.env.CODEBOT_HOME;
+    const cbHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-test-home-'));
+    process.env.CODEBOT_HOME = cbHome;
+    fs.mkdirSync(path.join(cbHome, 'skills'), { recursive: true });
+
+    // A minimal skill: one step that reads a fixture file. read_file is
+    // permission:'auto' and does NOT hit a CORD hard-block, so the
+    // inner step should pass through cleanly and — critically — go
+    // through executeSingleTool which writes a read_file audit entry.
+    // Pre-patch (`t.execute()` direct call) wrote no audit entry for
+    // the inner step.
+    const fixtureDirLocal = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-test-skill-'));
+    const fixtureFile = path.join(fixtureDirLocal, 'note.txt');
+    fs.writeFileSync(fixtureFile, 'skill-inner-step-reached\n');
+
+    fs.writeFileSync(
+      path.join(cbHome, 'skills', 'test-read.json'),
+      JSON.stringify({
+        name: 'test-read',
+        description: 'Read a fixture file — test harness skill',
+        parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+        steps: [{ tool: 'read_file', args: { path: '{{input.path}}' } }],
+      }),
+    );
+
+    try {
+      // Fresh agent so loadSkills() picks up the fixture skill.
+      //
+      // `constitutional.enabled: false` — CORD currently returns a
+      // score-based BLOCK for any `skill_*` tool (score ~22, regardless
+      // of inner step). With CORD on, the outer skill invocation would
+      // never reach its inner steps, so we couldn't verify the
+      // inner-step gate chain is now wired. That CORD aggressiveness
+      // against skills is a separate issue tracked outside this PR.
+      // Disabling CORD here isolates the test to exactly what this
+      // patch changes: the inner-step callback writing audit entries.
+      const localAgent = new Agent({
+        provider: makeStubProvider(),
+        model: 'stub-model',
+        providerName: 'stub',
+        projectRoot: fixtureDirLocal,
+        autoApprove: true,
+        constitutional: { enabled: false },
+      });
+      const sessionId = localAgent.getAuditLogger().getSessionId();
+
+      const reg = localAgent.getToolRegistry();
+      assert.ok(
+        reg.get('skill_test-read'),
+        `expected skill_test-read to be registered; got skills=${reg.all().map(t => t.name).filter(n => n.startsWith('skill_')).join(',')}`,
+      );
+
+      const outcome = await localAgent.runSingleTool(
+        'skill_test-read',
+        { path: fixtureFile },
+        { interactivePrompt: true },
+      );
+
+      // Inner step should have passed through executeSingleTool, which
+      // writes an audit entry for read_file. Pre-patch code wrote NONE
+      // for inner steps.
+      const entries = localAgent.getAuditLogger().query({ sessionId });
+      const innerReadEntries = entries.filter(e => e.tool === 'read_file');
+      assert.ok(
+        innerReadEntries.length > 0,
+        `expected ≥1 audit entry for inner read_file step, got entries=${JSON.stringify(entries.map(e => ({ tool: e.tool, action: e.action })))}; outcome=${JSON.stringify(outcome)}`,
+      );
+
+      // Sanity: the outer skill tool returned the inner result.
+      assert.ok(
+        String(outcome.result).includes('skill-inner-step-reached'),
+        `expected outer skill result to contain inner read output, got: ${outcome.result}`,
+      );
+    } finally {
+      if (origHome === undefined) delete process.env.CODEBOT_HOME;
+      else process.env.CODEBOT_HOME = origHome;
+      try { fs.rmSync(cbHome, { recursive: true }); } catch { /* ignore */ }
+      try { fs.rmSync(fixtureDirLocal, { recursive: true }); } catch { /* ignore */ }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes two layered bypasses of the tool-call gate chain (schema → policy → risk → CORD → SPARK → capability → permission → audit):

**Outer bypass** (`POST /api/command/tool/run`): previously invoked `tool.execute(body.args)` directly on the ToolRegistry entry, skipping every gate. A dashboard-token holder could drive any registered tool (`execute`, `write_file`, `docker`, `ssh_remote`, …) with zero CORD decisions and zero audit entries.

**Inner bypass** (skill step callback, flagged by reviewer as P1): `skillToTool`'s inner callback in `src/agent.ts` called `t.execute(args)` directly, so every step of a `skill_*` tool (including built-ins like `standup-summary` whose first step runs `execute git log ...`) bypassed the gate chain on that inner step even after the outer fix.

## Changes

- **`src/agent.ts`** — extract Phase 1 gate chain from `Agent.run()` into a private `_prepareToolCall` helper; add public `Agent.runSingleTool(toolName, args, opts)` that replays `_prepareToolCall` then `executeSingleTool`. Autonomous loop delegates to `_prepareToolCall` (behavior preserved: same ordering, same audit entries, same CHALLENGE / autoApprove semantics). Skill inner-step callback now calls `this.runSingleTool(name, args, { interactivePrompt: true })` instead of `t.execute(args)` so every step replays the full chain.
- **`src/dashboard/command-api.ts`** — `POST /api/command/tool/run` routes through `agent.runSingleTool(body.tool, body.args, { interactivePrompt: false })`. `skill_*` tools are rejected with 403 on this endpoint (defense in depth — dashboard UI uses its own skill launcher with plan/confirm). Response shape gains `blocked` and `reason`; unknown-tool 404 is preserved.
- **`src/dashboard/tool-run-bypass.test.ts`** (new) — acceptance tests for both layers.

`opts.interactivePrompt` defaults to `false` on `runSingleTool` — always-ask / prompt tools fail closed over HTTP because there is no user on the wire to answer a readline prompt.

## Scope

Row 1 of the 2026-04-23 direct-execution bypass sweep. Rows 2+ (`/api/command/exec`, CodeAGI routes, test-runner arg filter, graphics args, etc.) are deliberately out of scope and will land in separate narrow PRs.

## Test plan

- [x] Acceptance tests in `src/dashboard/tool-run-bypass.test.ts` — **5/5 pass**:
  1. Dangerous `execute` call → `blocked: true`, `is_error: true`, matching deny/block audit entry in the session's log.
  2. Safe `read_file` call → passes through, returns file contents.
  3. Unknown tool → `404` (pre-fix shape).
  4. `skill_standup-summary` over HTTP → `403` with error mentioning skills.
  5. Fixture skill with a `read_file` step invoked via `runSingleTool` → inner step writes a `read_file` audit entry (pre-patch wrote none); outer skill result contains the inner read output.
- [x] `npm run build` — clean.
- [x] `node --test dist/dashboard/*.test.js` — **55/55 pass** (no dashboard regressions).
- [x] `node scripts/run-tests.js` — 1679/1682 pass. The 3 failures are in the Anthropic provider suite and reproduce on clean `main` with this patch stashed (pre-existing, tracked separately).
- [x] `npm run lint` — 0 errors.

## Caveat flagged for separate task

While writing the inner-step audit test I found CORD returns a score-based `BLOCK` (score ~22.5, `hardBlock: false`) for any tool whose name starts with `skill_`. Under default CORD settings this would make skills unusable outright. The inner-step test disables CORD (`constitutional: { enabled: false }`) to isolate exactly what this PR changes — the inner step being audited. The CORD-vs-skills interaction is being tracked outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)