### PR TITLE
[SECURITY] Route /api/command/exec through agent gate chain + ExecuteTool

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,5 @@
 import * as readline from 'readline';
-import { Message, ToolCall, AgentEvent, LLMProvider, Tool } from './types';
+import { Message, ToolCall, AgentEvent, LLMProvider, Tool, ToolStreamEvents } from './types';
 import { ToolRegistry } from './tools';
 import { parseToolCalls } from './parser';
 import { ContextManager } from './context/manager';
@@ -883,6 +883,104 @@ export class Agent {
       blocked: false,
       durationMs: output.durationMs,
     };
+  }
+
+  /**
+   * Streaming single-tool entry point for non-LLM callers (dashboard
+   * SSE, IPC, scripts). Runs the full gate chain via `_prepareToolCall`,
+   * then — if allowed — invokes the tool's `stream()` method. Tools
+   * without `stream()` are rejected (only `execute` implements it today).
+   *
+   * Audit semantics — `_prepareToolCall` writes entries only for
+   * BLOCKS (policy/constitutional/capability/permission), not for
+   * allows. So `runStreamingTool` writes `exec_start` after the gate
+   * passes (the allow evidence), then `exec_complete` on process close
+   * with the 512-byte tails, or `exec_error` if `stream()` throws.
+   *
+   * Tail size is fixed at 512 bytes per stream inside the tool; never
+   * logs full output.
+   */
+  async runStreamingTool(
+    toolName: string,
+    args: Record<string, unknown>,
+    events: ToolStreamEvents,
+    opts: { interactivePrompt?: boolean; streamTimeoutMs?: number } = {},
+  ): Promise<
+    | { blocked: true; reason: string; errorCode?: string }
+    | { blocked: false; error: true; errorCode: string; reason: string }
+    | { blocked: false; error: false; exitCode: number; stdoutTail: string; stderrTail: string; timedOut: boolean }
+  > {
+    const { prepared } = await this._prepareToolCall(
+      toolName,
+      args ?? {},
+      { interactivePrompt: opts.interactivePrompt ?? false },
+    );
+
+    if (prepared.error) {
+      if (prepared.denied) {
+        return { blocked: true, reason: prepared.error };
+      }
+      return {
+        blocked: false,
+        error: true,
+        errorCode: 'gate_error',
+        reason: prepared.error,
+      };
+    }
+    if (prepared.denied) {
+      return { blocked: true, reason: 'Denied by policy / CORD / SPARK / permission gate' };
+    }
+
+    const tool = prepared.tool;
+    if (typeof tool.stream !== 'function') {
+      return {
+        blocked: false,
+        error: true,
+        errorCode: 'not_streamable',
+        reason: `Tool "${toolName}" does not support streaming execution.`,
+      };
+    }
+
+    // Allow evidence — `_prepareToolCall` doesn't audit allows, so we
+    // write exec_start here. This is the authoritative record that the
+    // gate chain approved this specific args payload for streaming.
+    this.auditLogger.log({
+      tool: toolName,
+      action: 'exec_start',
+      args,
+      reason: 'streaming execution approved by gate chain',
+    });
+
+    const startedAt = Date.now();
+    try {
+      const result = await tool.stream(args, events, { timeoutMs: opts.streamTimeoutMs });
+      this.auditLogger.log({
+        tool: toolName,
+        action: 'exec_complete',
+        args,
+        result: `exit:${result.exitCode}${result.timedOut ? ' timed_out' : ''}`,
+        reason: `stdout_tail=${JSON.stringify(result.stdoutTail)} stderr_tail=${JSON.stringify(result.stderrTail)} duration_ms=${Date.now() - startedAt}`,
+      });
+      return {
+        blocked: false,
+        error: false,
+        exitCode: result.exitCode,
+        stdoutTail: result.stdoutTail,
+        stderrTail: result.stderrTail,
+        timedOut: result.timedOut,
+      };
+    } catch (err: unknown) {
+      const e = err as { code?: string; message?: string };
+      const code = e.code || 'stream_error';
+      const reason = e.message || 'streaming exec failed';
+      this.auditLogger.log({
+        tool: toolName,
+        action: 'exec_error',
+        args,
+        reason: `code=${code} message=${reason} duration_ms=${Date.now() - startedAt}`,
+      });
+      return { blocked: false, error: true, errorCode: code, reason };
+    }
   }
 
   /** Get the policy enforcer for inspection */

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -941,6 +941,21 @@ export class Agent {
       };
     }
 
+    // Fine-grained capability check — the buffered path runs this
+    // inside executeSingleTool() (src/agent/tool-executor.ts:79), but
+    // `_prepareToolCall` does NOT. Without this call, a policy like
+    //   tools.capabilities.execute.shell_commands: ['npm']
+    // would block `npm install` via the buffered tool runner but let
+    // `git status` stream through /api/command/exec unchecked. Mirror
+    // the exact contract: audit `capability_block`, bump the same
+    // metric tag the buffered path uses, return a blocked outcome.
+    const capBlock = this.checkToolCapabilities(toolName, args);
+    if (capBlock) {
+      this.auditLogger.log({ tool: toolName, action: 'capability_block', args, reason: capBlock });
+      this.metricsCollector.increment('security_blocks_total', { tool: toolName, type: 'capability' });
+      return { blocked: true, reason: capBlock, errorCode: 'capability_block' };
+    }
+
     // Allow evidence — `_prepareToolCall` doesn't audit allows, so we
     // write exec_start here. This is the authoritative record that the
     // gate chain approved this specific args payload for streaming.

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -24,7 +24,23 @@ export interface AuditEntry {
   sessionId: string;
   sequence: number;
   tool: string;
-  action: 'execute' | 'deny' | 'error' | 'security_block' | 'policy_block' | 'capability_block' | 'constitutional_block';
+  action:
+    | 'execute'
+    | 'deny'
+    | 'error'
+    | 'security_block'
+    | 'policy_block'
+    | 'capability_block'
+    | 'constitutional_block'
+    // Streaming-exec actions (dashboard terminal). exec_start is the
+    // allow evidence written after the gate chain passes; _prepareToolCall
+    // does not audit allows, so without this the streaming path would
+    // leave no positive trail. exec_complete records exitCode + 512-byte
+    // tails. exec_error records tool-level refusals (sandbox_required,
+    // spawn_error, etc.).
+    | 'exec_start'
+    | 'exec_complete'
+    | 'exec_error';
   args: Record<string, unknown>;
   result?: string;
   reason?: string;

--- a/src/dashboard/command-api.ts
+++ b/src/dashboard/command-api.ts
@@ -558,8 +558,24 @@ export function registerCommandRoutes(
     // patterns, but this guarantees a 403 before any SSE headers go
     // out for the obvious bad cases, and keeps the standalone path
     // working unchanged if the agent is unavailable.
+    //
+    // Audit honesty: when the agent is attached, log the block through
+    // the agent's audit logger so the claim "dangerous command blocked
+    // and audited" is actually true on this code path. If the request
+    // never reaches `runStreamingTool`, nothing downstream will ever
+    // write that entry for us. Standalone mode has no audit logger —
+    // that is a known gap and is exactly what `guarded:false` warns
+    // about in the init event.
     for (const pattern of BLOCKED_PATTERNS) {
       if (pattern.test(body.command)) {
+        if (agent) {
+          agent.getAuditLogger().log({
+            tool: 'execute',
+            action: 'policy_block',
+            args: { command: body.command, ...(typeof body.cwd === 'string' ? { cwd: body.cwd } : {}) },
+            reason: 'inline BLOCKED_PATTERNS pre-check (dashboard /api/command/exec)',
+          });
+        }
         DashboardServer.error(res, 403, 'Blocked: dangerous command pattern detected');
         return;
       }

--- a/src/dashboard/command-api.ts
+++ b/src/dashboard/command-api.ts
@@ -36,13 +36,18 @@ function filteredEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
-/** Spawn a shell command and stream stdout/stderr as SSE events */
+/**
+ * Spawn a shell command and stream stdout/stderr as SSE events.
+ * `headersAlreadySent` lets the caller write headers + an init event
+ * first, then invoke this without double-writing status/headers.
+ */
 function execAndStream(
   res: http.ServerResponse,
   command: string,
   cwd?: string,
+  headersAlreadySent = false,
 ): void {
-  DashboardServer.sseHeaders(res);
+  if (!headersAlreadySent) DashboardServer.sseHeaders(res);
 
   let closed = false;
   const child = spawn('sh', ['-c', command], {
@@ -523,7 +528,17 @@ export function registerCommandRoutes(
     execAndStream(res, actionDef.command);
   });
 
-  // ── POST /api/command/exec (always works) ──
+  // ── POST /api/command/exec ──
+  //
+  // Agent-backed mode (default): routes through Agent.runStreamingTool
+  // → ExecuteTool.stream, replaying the full gate chain (policy, risk,
+  // CORD, SPARK, capability, permission) AND the tool's own preflight
+  // (BLOCKED_PATTERNS, cwd containment, sandbox decision). Writes
+  // exec_start / exec_complete / exec_error audit entries.
+  //
+  // Standalone mode (agent=null): keeps the pre-2026-04-24 behavior —
+  // inline regex check + direct spawn. The SSE init event advertises
+  // `{ mode: 'standalone', guarded: false }` so clients can warn.
   server.route('POST', '/api/command/exec', async (req, res) => {
     let body: { command?: string; cwd?: string };
     try {
@@ -538,6 +553,11 @@ export function registerCommandRoutes(
       return;
     }
 
+    // Belt-and-suspenders: keep the inline regex pre-check even in
+    // agent-backed mode. The tool-level preflight re-checks the same
+    // patterns, but this guarantees a 403 before any SSE headers go
+    // out for the obvious bad cases, and keeps the standalone path
+    // working unchanged if the agent is unavailable.
     for (const pattern of BLOCKED_PATTERNS) {
       if (pattern.test(body.command)) {
         DashboardServer.error(res, 403, 'Blocked: dangerous command pattern detected');
@@ -545,7 +565,54 @@ export function registerCommandRoutes(
       }
     }
 
-    execAndStream(res, body.command, body.cwd);
+    if (!agent) {
+      DashboardServer.sseHeaders(res);
+      DashboardServer.sseSend(res, { type: 'init', mode: 'standalone', guarded: false });
+      execAndStream(res, body.command, body.cwd, /* headersAlreadySent */ true);
+      return;
+    }
+
+    DashboardServer.sseHeaders(res);
+    DashboardServer.sseSend(res, { type: 'init', mode: 'agent', guarded: true });
+
+    // Schema validator rejects `cwd: undefined` (expected string), so
+    // only include cwd in args when the caller actually supplied one.
+    // The tool defaults to projectRoot when cwd is absent.
+    const streamArgs: Record<string, unknown> = { command: body.command };
+    if (typeof body.cwd === 'string' && body.cwd.length > 0) {
+      streamArgs.cwd = body.cwd;
+    }
+
+    const outcome = await agent.runStreamingTool(
+      'execute',
+      streamArgs,
+      {
+        onStdout: (text) => DashboardServer.sseSend(res, { type: 'stdout', text }),
+        onStderr: (text) => DashboardServer.sseSend(res, { type: 'stderr', text }),
+      },
+      { interactivePrompt: false, streamTimeoutMs: 30_000 },
+    );
+
+    if (outcome.blocked) {
+      DashboardServer.sseSend(res, { type: 'blocked', reason: outcome.reason });
+      DashboardServer.sseClose(res);
+      return;
+    }
+    if (outcome.error) {
+      // Map tool-level refusals to structured SSE events. The client
+      // currently renders these as a red line in the terminal UI.
+      const httpCode = outcome.errorCode === 'sandbox_required' ? 501 : 500;
+      DashboardServer.sseSend(res, {
+        type: 'error',
+        code: httpCode,
+        errorCode: outcome.errorCode,
+        reason: outcome.reason,
+      });
+      DashboardServer.sseClose(res);
+      return;
+    }
+    DashboardServer.sseSend(res, { type: 'exit', code: outcome.exitCode });
+    DashboardServer.sseClose(res);
   });
 
 

--- a/src/dashboard/exec-gate.test.ts
+++ b/src/dashboard/exec-gate.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, afterEach } from 'node:test';
+import * as assert from 'node:assert';
+import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { DashboardServer } from './server';
+import { registerCommandRoutes } from './command-api';
+import { Agent } from '../agent';
+import { ExecuteTool } from '../tools/execute';
+import type { LLMProvider, AgentEvent } from '../types';
+
+/**
+ * Acceptance tests for the POST /api/command/exec gate-chain fix
+ * (2026-04-24 SECURITY).
+ *
+ * Before this fix the endpoint parsed a body, ran a regex pre-check, and
+ * spawned `sh -c <command>` directly — bypassing schema validation,
+ * policy allow-list, risk scoring, CORD, SPARK, capability, permission,
+ * AuditLogger, isCwdSafe containment, and sandbox routing. A dashboard-
+ * token holder could run arbitrary shell commands with zero audit trail.
+ *
+ * The fix routes the endpoint through Agent.runStreamingTool →
+ * ExecuteTool.stream. Gate chain runs at the Agent layer; preflight
+ * (patterns + cwd + sandbox) runs again inside the tool. Audit entries
+ * written: exec_start (allow evidence), exec_complete (exit + tails) or
+ * exec_error (sandbox_required, spawn_error, etc.).
+ *
+ * Required coverage:
+ *   1. dangerous command blocked, audited, no stdout
+ *   2. safe command streams stdout + exit 0, audits exec_start + exec_complete
+ *   3. cwd outside project blocked
+ *   4. sandbox-required streaming returns 501 and writes exec_error, no host spawn
+ *   5. standalone agent=null still streams with init {mode:'standalone', guarded:false} and keeps regex block
+ *   6. ExecuteTool preflight parity for accepted/rejected cases
+ */
+
+function sseRequest(
+  url: string,
+  token: string,
+  body: unknown,
+): Promise<{ status: number; events: Array<Record<string, unknown>>; raw: string }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'text/event-stream',
+    };
+    const req = http.request(url, { method: 'POST', headers }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf-8');
+        const events: Array<Record<string, unknown>> = [];
+        if (res.headers['content-type']?.includes('text/event-stream')) {
+          for (const block of raw.split('\n\n')) {
+            const dataLine = block.split('\n').find((l) => l.startsWith('data: '));
+            if (!dataLine) continue;
+            try { events.push(JSON.parse(dataLine.slice(6))); } catch { /* skip */ }
+          }
+        }
+        resolve({ status: res.statusCode || 0, events, raw });
+      });
+    });
+    req.on('error', reject);
+    req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+function makeStubProvider(): LLMProvider {
+  return {
+    name: 'stub',
+    async *chat(): AsyncGenerator<AgentEvent> {
+      yield { type: 'done' };
+    },
+  } as LLMProvider;
+}
+
+let portCounter = 15720;
+function nextPort(): number { return portCounter++; }
+
+describe('POST /api/command/exec — gate chain', () => {
+  let server: DashboardServer | null = null;
+  let agent: Agent | null = null;
+  let fixtureDir: string | null = null;
+
+  afterEach(async () => {
+    if (server && server.isRunning()) await server.stop();
+    server = null;
+    if (fixtureDir && fs.existsSync(fixtureDir)) {
+      try { fs.rmSync(fixtureDir, { recursive: true }); } catch { /* ignore */ }
+    }
+    fixtureDir = null;
+    agent = null;
+  });
+
+  async function startServer(
+    overrides: { agentless?: boolean; policy?: Record<string, unknown> } = {},
+  ): Promise<{ port: number; token: string; sessionId: string | null }> {
+    // Realpath the tmp dir — on macOS, `/var/folders/...` is a symlink
+    // to `/private/var/folders/...`, and isCwdSafe compares the
+    // *realpath* of a cwd to the *non-realpath* projectRoot. If we
+    // don't resolve the symlink here, ExecuteTool rejects its own
+    // default cwd as unsafe.
+    fixtureDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'cb-test-exec-gate-')),
+    );
+
+    if (overrides.policy) {
+      fs.mkdirSync(path.join(fixtureDir, '.codebot'), { recursive: true });
+      fs.writeFileSync(
+        path.join(fixtureDir, '.codebot', 'policy.json'),
+        JSON.stringify(overrides.policy, null, 2),
+      );
+    }
+
+    let sessionId: string | null = null;
+    if (!overrides.agentless) {
+      // `constitutional.enabled: false` — CORD currently score-blocks
+      // many benign `execute` commands based on string contents (e.g.
+      // "echo hello-from-exec-stream" scores 11 → BLOCK regardless of
+      // tool semantics). That's a separate CORD-tuning issue already
+      // tracked outside this PR; disabling here isolates these tests
+      // to exactly what this patch changes: the gate-chain wiring and
+      // ExecuteTool streaming. Policy / capability / permission /
+      // preflight still run. autoApprove matches production dashboard.
+      agent = new Agent({
+        provider: makeStubProvider(),
+        model: 'stub-model',
+        providerName: 'stub',
+        projectRoot: fixtureDir,
+        autoApprove: true,
+        constitutional: { enabled: false },
+      });
+      sessionId = agent.getAuditLogger().getSessionId();
+    }
+
+    const port = nextPort();
+    server = new DashboardServer({ port });
+    registerCommandRoutes(server, agent);
+    await server.start();
+    return { port, token: server.getAuthToken(), sessionId };
+  }
+
+  // ── Test 1: dangerous command blocked, audited, no stdout ────────────
+  it('blocks a dangerous command and writes a deny/block audit entry', async () => {
+    const { port, token, sessionId } = await startServer();
+
+    const res = await sseRequest(
+      `http://127.0.0.1:${port}/api/command/exec`,
+      token,
+      { command: 'rm -rf /' },
+    );
+
+    // The inline regex pre-check returns a 403 JSON error before SSE
+    // headers go out. That is the belt-and-suspenders layer: even if
+    // the gate chain somehow allowed it, this wall catches it first.
+    assert.strictEqual(res.status, 403, `expected 403, got ${res.status}: ${res.raw}`);
+    assert.match(
+      res.raw,
+      /blocked|dangerous/i,
+      `expected block message, got: ${res.raw}`,
+    );
+    // No stdout streamed under any circumstances.
+    assert.ok(
+      !res.events.some((e) => e.type === 'stdout'),
+      `expected no stdout events on block, got events=${JSON.stringify(res.events)}`,
+    );
+
+    // Regex pre-check short-circuits before reaching the gate chain, so
+    // we don't expect an audit entry in this specific case. But if the
+    // inline wall is ever removed, the gate-chain path must fire. Prove
+    // that too: send an evasive variant that the inline regex does NOT
+    // match but that CORD / preflight should catch inside the tool.
+    // (The pre-check list is conservative; the tool repeats it.)
+    const res2 = await sseRequest(
+      `http://127.0.0.1:${port}/api/command/exec`,
+      token,
+      // `rm -rf /etc` — destructive but not exactly matching the `/`
+      // root-delete regex in BLOCKED_PATTERNS. Whether this is caught
+      // depends on CORD. What we assert here is the property that
+      // matters: if the command reaches the tool and is rejected, an
+      // audit entry exists. If it streams, it was allowed (and that
+      // is a separate issue for CORD tuning, not this bypass fix).
+      { command: 'echo via-gate-chain' },
+    );
+    // sanity: that one reaches the gate chain
+    assert.strictEqual(res2.status, 200, `expected 200 on allowed command, got ${res2.status}`);
+    const entries = agent!.getAuditLogger().query({ sessionId: sessionId! });
+    const execEntries = entries.filter((e) => e.tool === 'execute');
+    assert.ok(
+      execEntries.some((e) => e.action === 'exec_start'),
+      `expected an exec_start audit entry for the allowed command, got ${JSON.stringify(execEntries.map((e) => ({ tool: e.tool, action: e.action })))}`,
+    );
+  });
+
+  // ── Test 2: safe command streams + audits ─────────────────────────────
+  it('streams a safe command, exits 0, writes exec_start + exec_complete', async () => {
+    const { port, token, sessionId } = await startServer();
+
+    const res = await sseRequest(
+      `http://127.0.0.1:${port}/api/command/exec`,
+      token,
+      { command: 'echo hello-from-exec-stream' },
+    );
+
+    assert.strictEqual(res.status, 200, `expected 200, got ${res.status}: ${res.raw}`);
+
+    const init = res.events.find((e) => e.type === 'init');
+    assert.ok(init, `expected init event, got events=${JSON.stringify(res.events)}`);
+    assert.strictEqual(init!.mode, 'agent');
+    assert.strictEqual(init!.guarded, true);
+
+    const stdout = res.events.filter((e) => e.type === 'stdout').map((e) => e.text).join('');
+    assert.ok(
+      stdout.includes('hello-from-exec-stream'),
+      `expected stdout to contain fixture marker, got stdout=${JSON.stringify(stdout)}, all events=${JSON.stringify(res.events)}, raw=${JSON.stringify(res.raw.slice(0, 500))}`,
+    );
+
+    const exit = res.events.find((e) => e.type === 'exit');
+    assert.ok(exit, `expected exit event, got events=${JSON.stringify(res.events)}`);
+    assert.strictEqual(exit!.code, 0, `expected exit code 0, got ${exit!.code}`);
+
+    // Audit: one exec_start (allow evidence) + one exec_complete.
+    const entries = agent!.getAuditLogger().query({ sessionId: sessionId! });
+    const execStart = entries.filter((e) => e.tool === 'execute' && e.action === 'exec_start');
+    const execComplete = entries.filter((e) => e.tool === 'execute' && e.action === 'exec_complete');
+    assert.strictEqual(
+      execStart.length,
+      1,
+      `expected exactly 1 exec_start entry, got ${execStart.length}: ${JSON.stringify(execStart)}`,
+    );
+    assert.strictEqual(
+      execComplete.length,
+      1,
+      `expected exactly 1 exec_complete entry, got ${execComplete.length}: ${JSON.stringify(execComplete)}`,
+    );
+    assert.match(
+      String(execComplete[0].result),
+      /exit:0/,
+      `expected exec_complete result to tag exit:0, got: ${execComplete[0].result}`,
+    );
+    // Tail must be present and must not be full output dumped in.
+    // Our fixture is "hello-from-exec-stream\n" — well under 512 bytes.
+    assert.match(
+      String(execComplete[0].reason),
+      /stdout_tail=.*hello-from-exec-stream/,
+      `expected stdout tail in reason, got: ${execComplete[0].reason}`,
+    );
+  });
+
+  // ── Test 3: cwd outside project blocked ──────────────────────────────
+  it('blocks a command whose cwd escapes the project root', async () => {
+    const { port, token, sessionId } = await startServer();
+
+    const res = await sseRequest(
+      `http://127.0.0.1:${port}/api/command/exec`,
+      token,
+      { command: 'echo hi', cwd: '/etc' },
+    );
+
+    // Gate chain lets a policy-allowed command through; the tool's own
+    // preflight catches the cwd escape and throws with code 'unsafe_cwd'.
+    // runStreamingTool maps that to an error (500) SSE event.
+    assert.strictEqual(res.status, 200, `expected 200 (SSE), got ${res.status}: ${res.raw}`);
+    const err = res.events.find((e) => e.type === 'error');
+    assert.ok(err, `expected an error event for unsafe_cwd, got events=${JSON.stringify(res.events)}`);
+    assert.strictEqual(err!.errorCode, 'unsafe_cwd');
+    assert.ok(
+      !res.events.some((e) => e.type === 'stdout'),
+      'must not stream any stdout when cwd is unsafe',
+    );
+    assert.ok(
+      !res.events.some((e) => e.type === 'exit'),
+      'must not emit an exit event — process never spawned',
+    );
+
+    const entries = agent!.getAuditLogger().query({ sessionId: sessionId! });
+    const execError = entries.filter((e) => e.tool === 'execute' && e.action === 'exec_error');
+    assert.ok(
+      execError.length > 0,
+      `expected ≥1 exec_error audit entry, got ${JSON.stringify(entries.map((e) => ({ tool: e.tool, action: e.action })))}`,
+    );
+    assert.match(
+      String(execError[0].reason),
+      /unsafe_cwd/,
+      `expected unsafe_cwd in reason, got: ${execError[0].reason}`,
+    );
+  });
+
+  // ── Test 4: sandbox-required streaming returns 501, no host spawn ────
+  it('fails closed with 501 when policy requires sandbox for streaming exec', async () => {
+    // validatePolicy() requires `version` as string (not number) — a
+    // numeric version silently fails validation and the file is ignored.
+    const { port, token, sessionId } = await startServer({
+      policy: {
+        version: '1',
+        execution: { sandbox: 'docker' },
+      },
+    });
+
+    const res = await sseRequest(
+      `http://127.0.0.1:${port}/api/command/exec`,
+      token,
+      { command: 'echo must-not-reach-host' },
+    );
+
+    assert.strictEqual(res.status, 200, `expected 200 SSE framing, got ${res.status}: ${res.raw}`);
+    const err = res.events.find((e) => e.type === 'error');
+    assert.ok(err, `expected error event, got events=${JSON.stringify(res.events)}`);
+    assert.strictEqual(err!.code, 501, `expected HTTP-mapped code 501, got ${err!.code}`);
+    assert.strictEqual(err!.errorCode, 'sandbox_required');
+    assert.match(
+      String(err!.reason),
+      /sandbox/i,
+      `expected sandbox mention in reason, got: ${err!.reason}`,
+    );
+    assert.ok(
+      !res.events.some((e) => e.type === 'stdout'),
+      'must not stream any stdout — no host spawn allowed when sandbox required',
+    );
+    assert.ok(
+      !res.events.some((e) => e.type === 'exit'),
+      'must not emit exit — process never spawned',
+    );
+
+    const entries = agent!.getAuditLogger().query({ sessionId: sessionId! });
+    const execError = entries.filter((e) => e.tool === 'execute' && e.action === 'exec_error');
+    assert.ok(
+      execError.length > 0,
+      'expected exec_error audit entry for sandbox_required refusal',
+    );
+    assert.match(
+      String(execError[0].reason),
+      /sandbox_required/,
+      `expected sandbox_required code in reason, got: ${execError[0].reason}`,
+    );
+  });
+
+  // ── Test 5: standalone agent=null still streams, regex block intact ──
+  it('standalone mode (agent=null) streams with guarded:false and keeps regex block', async () => {
+    const { port, token } = await startServer({ agentless: true });
+
+    // Safe command still streams end-to-end.
+    const okRes = await sseRequest(
+      `http://127.0.0.1:${port}/api/command/exec`,
+      token,
+      { command: 'echo standalone-path' },
+    );
+    assert.strictEqual(okRes.status, 200, `expected 200, got ${okRes.status}: ${okRes.raw}`);
+    const init = okRes.events.find((e) => e.type === 'init');
+    assert.ok(init, `expected init event, got events=${JSON.stringify(okRes.events)}`);
+    assert.strictEqual(init!.mode, 'standalone');
+    assert.strictEqual(init!.guarded, false);
+    const stdout = okRes.events.filter((e) => e.type === 'stdout').map((e) => e.text).join('');
+    assert.ok(
+      stdout.includes('standalone-path'),
+      `expected stdout to contain fixture marker, got: ${stdout}`,
+    );
+
+    // Dangerous command still blocked by the inline regex — standalone
+    // mode has no gate chain to fall back to, so this wall is the only
+    // defense and must not be removed.
+    const badRes = await sseRequest(
+      `http://127.0.0.1:${port}/api/command/exec`,
+      token,
+      { command: 'rm -rf /' },
+    );
+    assert.strictEqual(badRes.status, 403, `expected 403, got ${badRes.status}: ${badRes.raw}`);
+    assert.ok(
+      !badRes.events.some((e) => e.type === 'stdout'),
+      'dangerous command must not stream anything in standalone mode',
+    );
+  });
+
+  // ── Test 6: ExecuteTool preflight parity ─────────────────────────────
+  it('ExecuteTool.preflight produces the same accept/reject decisions as execute()', async () => {
+    // See startServer() comment on realpath — macOS tmpdir is a symlink
+    // and isCwdSafe fails without resolving.
+    const root = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'cb-test-preflight-')),
+    );
+    try {
+      const tool = new ExecuteTool(root);
+
+      // Accepted — execute() must produce output; preflight must produce an ok:true plan.
+      const okCases = [
+        { command: 'echo parity-ok' },
+        { command: 'true' },
+      ];
+      for (const args of okCases) {
+        const pre = tool.preflight(args);
+        assert.strictEqual(pre.ok, true, `preflight should accept: ${JSON.stringify(args)}`);
+        const out = await tool.execute(args);
+        assert.ok(
+          !out.startsWith('Error:'),
+          `execute() should not return Error: for ${JSON.stringify(args)}, got: ${out}`,
+        );
+      }
+
+      // Rejected — blocked pattern: preflight returns code 'blocked_pattern';
+      // execute() throws (historical contract preserved).
+      const preBlock = tool.preflight({ command: 'rm -rf /' });
+      assert.strictEqual(preBlock.ok, false);
+      if (!preBlock.ok) {
+        assert.strictEqual(preBlock.code, 'blocked_pattern');
+      }
+      await assert.rejects(
+        () => tool.execute({ command: 'rm -rf /' }),
+        /Blocked|dangerous/i,
+        'execute() must throw for blocked patterns',
+      );
+
+      // Rejected — missing command: preflight 'bad_args'; execute returns Error:.
+      const preBad = tool.preflight({});
+      assert.strictEqual(preBad.ok, false);
+      if (!preBad.ok) {
+        assert.strictEqual(preBad.code, 'bad_args');
+      }
+      const badOut = await tool.execute({});
+      assert.match(badOut, /^Error:/, 'execute() must return Error: string for missing command');
+
+      // Rejected — unsafe cwd: preflight 'unsafe_cwd'; execute returns Error:.
+      const preCwd = tool.preflight({ command: 'echo x', cwd: '/etc' });
+      assert.strictEqual(preCwd.ok, false);
+      if (!preCwd.ok) {
+        assert.strictEqual(preCwd.code, 'unsafe_cwd');
+      }
+      const cwdOut = await tool.execute({ command: 'echo x', cwd: '/etc' });
+      assert.match(cwdOut, /^Error:/, 'execute() must return Error: string for unsafe cwd');
+    } finally {
+      try { fs.rmSync(root, { recursive: true }); } catch { /* ignore */ }
+    }
+  });
+});

--- a/src/dashboard/exec-gate.test.ts
+++ b/src/dashboard/exec-gate.test.ts
@@ -27,12 +27,16 @@ import type { LLMProvider, AgentEvent } from '../types';
  * exec_error (sandbox_required, spawn_error, etc.).
  *
  * Required coverage:
- *   1. dangerous command blocked, audited, no stdout
+ *   1. dangerous command blocked, audited (inline-regex 403 now writes
+ *      a `policy_block` audit entry in agent-backed mode), no stdout
  *   2. safe command streams stdout + exit 0, audits exec_start + exec_complete
  *   3. cwd outside project blocked
  *   4. sandbox-required streaming returns 501 and writes exec_error, no host spawn
  *   5. standalone agent=null still streams with init {mode:'standalone', guarded:false} and keeps regex block
  *   6. ExecuteTool preflight parity for accepted/rejected cases
+ *   7. fine-grained capability check blocks streaming for disallowed
+ *      shell_commands prefix (mirrors the buffered path's capability
+ *      gate — /api/command/exec must not bypass it)
  */
 
 function sseRequest(
@@ -168,24 +172,33 @@ describe('POST /api/command/exec — gate chain', () => {
       `expected no stdout events on block, got events=${JSON.stringify(res.events)}`,
     );
 
-    // Regex pre-check short-circuits before reaching the gate chain, so
-    // we don't expect an audit entry in this specific case. But if the
-    // inline wall is ever removed, the gate-chain path must fire. Prove
-    // that too: send an evasive variant that the inline regex does NOT
-    // match but that CORD / preflight should catch inside the tool.
-    // (The pre-check list is conservative; the tool repeats it.)
+    // Audit honesty: agent-backed mode now writes a `policy_block`
+    // audit entry before returning the inline-regex 403. Without this
+    // entry the PR claim "dangerous command blocked AND audited" is a
+    // lie on the inline-wall code path. The entry must carry the
+    // command so forensics can reconstruct what was attempted.
+    const earlyEntries = agent!.getAuditLogger().query({ sessionId: sessionId! });
+    const earlyBlocks = earlyEntries.filter(
+      (e) => e.tool === 'execute' && e.action === 'policy_block',
+    );
+    assert.ok(
+      earlyBlocks.length >= 1,
+      `expected ≥1 policy_block audit entry for inline-regex 403, got entries=${JSON.stringify(earlyEntries.map((e) => ({ tool: e.tool, action: e.action })))}`,
+    );
+    assert.strictEqual(
+      (earlyBlocks[0].args as { command?: string }).command,
+      'rm -rf /',
+      `expected audit entry to record the attempted command, got: ${JSON.stringify(earlyBlocks[0].args)}`,
+    );
+
+    // Gate-chain allow path: send a benign command that the inline
+    // regex does NOT match, prove it reaches the tool and produces the
+    // `exec_start` allow-evidence entry.
     const res2 = await sseRequest(
       `http://127.0.0.1:${port}/api/command/exec`,
       token,
-      // `rm -rf /etc` — destructive but not exactly matching the `/`
-      // root-delete regex in BLOCKED_PATTERNS. Whether this is caught
-      // depends on CORD. What we assert here is the property that
-      // matters: if the command reaches the tool and is rejected, an
-      // audit entry exists. If it streams, it was allowed (and that
-      // is a separate issue for CORD tuning, not this bypass fix).
       { command: 'echo via-gate-chain' },
     );
-    // sanity: that one reaches the gate chain
     assert.strictEqual(res2.status, 200, `expected 200 on allowed command, got ${res2.status}`);
     const entries = agent!.getAuditLogger().query({ sessionId: sessionId! });
     const execEntries = entries.filter((e) => e.tool === 'execute');
@@ -432,5 +445,108 @@ describe('POST /api/command/exec — gate chain', () => {
     } finally {
       try { fs.rmSync(root, { recursive: true }); } catch { /* ignore */ }
     }
+  });
+
+  // ── Test 7: fine-grained capability check blocks streaming ──────────
+  //
+  // The buffered tool runner (`executeSingleTool`) calls
+  // `checkToolCapabilities` after `_prepareToolCall`. The streaming path
+  // (`runStreamingTool`) must do the same, otherwise a policy that
+  // restricts execute.shell_commands to e.g. 'npm' would block
+  // `git status` via `runSingleTool` but let it stream through
+  // /api/command/exec. This test proves the capability gate is enforced
+  // on the streaming path and the block is audited as `capability_block`.
+  it('blocks streaming exec when command prefix is outside capability allow-list', async () => {
+    const { port, token, sessionId } = await startServer({
+      policy: {
+        version: '1',
+        tools: {
+          capabilities: {
+            execute: {
+              // Only `echo` prefix is allowed. The gate chain's policy
+              // allow-list is empty (= all tools enabled), inline
+              // BLOCKED_PATTERNS does not match `ls`, and CORD is
+              // disabled in startServer(). The ONLY thing standing
+              // between `ls /tmp` and a host spawn is the capability
+              // check inside runStreamingTool.
+              shell_commands: ['echo'],
+            },
+          },
+        },
+      },
+    });
+
+    // Allowed prefix — must reach the tool and stream.
+    const okRes = await sseRequest(
+      `http://127.0.0.1:${port}/api/command/exec`,
+      token,
+      { command: 'echo capability-allowed' },
+    );
+    assert.strictEqual(okRes.status, 200, `expected 200, got ${okRes.status}: ${okRes.raw}`);
+    const okExit = okRes.events.find((e) => e.type === 'exit');
+    assert.ok(okExit, `expected exit event for allowed prefix, got: ${JSON.stringify(okRes.events)}`);
+    assert.strictEqual(okExit!.code, 0);
+
+    // Disallowed prefix — `ls` is not in shell_commands. Must be
+    // blocked at the agent layer, must emit a blocked SSE event, must
+    // NOT stream stdout, must NOT emit an exit event.
+    const badRes = await sseRequest(
+      `http://127.0.0.1:${port}/api/command/exec`,
+      token,
+      { command: 'ls /tmp' },
+    );
+    assert.strictEqual(badRes.status, 200, `expected 200 SSE, got ${badRes.status}: ${badRes.raw}`);
+    const blocked = badRes.events.find((e) => e.type === 'blocked');
+    assert.ok(
+      blocked,
+      `expected blocked SSE event for capability-denied command, got events=${JSON.stringify(badRes.events)}`,
+    );
+    assert.match(
+      String(blocked!.reason),
+      /shell_commands|cannot run|capability/i,
+      `expected capability-shaped reason, got: ${blocked!.reason}`,
+    );
+    assert.ok(
+      !badRes.events.some((e) => e.type === 'stdout'),
+      'capability-blocked command must not stream any stdout',
+    );
+    assert.ok(
+      !badRes.events.some((e) => e.type === 'exit'),
+      'capability-blocked command must not spawn a process — no exit event',
+    );
+
+    // Audit — a `capability_block` entry for the execute tool with the
+    // attempted command. No `exec_start` for the blocked command (that
+    // would mean the block happened AFTER allow evidence was written,
+    // which is wrong).
+    const entries = agent!.getAuditLogger().query({ sessionId: sessionId! });
+    const capBlocks = entries.filter(
+      (e) => e.tool === 'execute' && e.action === 'capability_block',
+    );
+    assert.ok(
+      capBlocks.length >= 1,
+      `expected ≥1 capability_block audit entry, got ${JSON.stringify(entries.map((e) => ({ tool: e.tool, action: e.action })))}`,
+    );
+    const capBlock = capBlocks.find(
+      (e) => (e.args as { command?: string }).command === 'ls /tmp',
+    );
+    assert.ok(
+      capBlock,
+      `expected capability_block entry for 'ls /tmp', got: ${JSON.stringify(capBlocks.map((e) => e.args))}`,
+    );
+
+    // No exec_start for the blocked command — allow evidence must not
+    // precede a block.
+    const starts = entries.filter(
+      (e) =>
+        e.tool === 'execute' &&
+        e.action === 'exec_start' &&
+        (e.args as { command?: string }).command === 'ls /tmp',
+    );
+    assert.strictEqual(
+      starts.length,
+      0,
+      `exec_start must not be written for capability-blocked command, got ${JSON.stringify(starts)}`,
+    );
   });
 });

--- a/src/tools/execute.ts
+++ b/src/tools/execute.ts
@@ -1,8 +1,72 @@
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import { Tool } from '../types';
 import { isCwdSafe } from '../security';
 import { sandboxExec, isDockerAvailable } from '../sandbox';
 import { PolicyEnforcer } from '../policy';
+
+/**
+ * Stream events emitted by {@link ExecuteTool.stream}. Transport-agnostic —
+ * the HTTP/SSE bridge lives in the dashboard layer, not here.
+ */
+export interface ExecStreamEvents {
+  onStdout?: (text: string) => void;
+  onStderr?: (text: string) => void;
+}
+
+/**
+ * Machine-readable failure codes for streaming exec. The dashboard maps
+ * `sandbox_required` → HTTP 501 ("transport cannot satisfy policy"), and
+ * the other codes → 403 (the gate itself refused the command).
+ */
+export type ExecStreamErrorCode =
+  | 'bad_args'
+  | 'blocked_pattern'
+  | 'unsafe_cwd'
+  | 'sandbox_required'
+  | 'spawn_error';
+
+export class ExecStreamError extends Error {
+  readonly code: ExecStreamErrorCode;
+  constructor(message: string, code: ExecStreamErrorCode) {
+    super(message);
+    this.name = 'ExecStreamError';
+    this.code = code;
+  }
+}
+
+/** Result of a successful streaming exec. Tails capped at 512 bytes each. */
+export interface ExecStreamResult {
+  exitCode: number;
+  stdoutTail: string;
+  stderrTail: string;
+  timedOut: boolean;
+}
+
+/** Validated execution plan produced by {@link ExecuteTool.preflight}. */
+interface ExecPlan {
+  cmd: string;
+  cwd: string;
+  timeoutMs: number;
+  useSandbox: boolean;
+  sandboxMode: 'auto' | 'docker' | 'host';
+  sandboxNetwork: boolean;
+  sandboxMemoryMb: number;
+  safeEnv: NodeJS.ProcessEnv;
+}
+
+/** Outcome of {@link ExecuteTool.preflight} — plan on success, structured reason on failure. */
+export type PreflightResult =
+  | { ok: true; plan: ExecPlan }
+  | { ok: false; reason: string; code: 'bad_args' | 'blocked_pattern' | 'unsafe_cwd' };
+
+const STREAM_TAIL_MAX = 512;
+
+function clampTail(chunks: string[]): string {
+  if (chunks.length === 0) return '';
+  const joined = chunks.join('');
+  if (joined.length <= STREAM_TAIL_MAX) return joined;
+  return joined.slice(joined.length - STREAM_TAIL_MAX);
+}
 
 export const BLOCKED_PATTERNS = [
   // Destructive filesystem operations
@@ -100,40 +164,125 @@ export class ExecuteTool implements Tool {
     required: ['command'],
   };
 
-  async execute(args: Record<string, unknown>): Promise<string> {
+  /**
+   * Shared preflight — validates args, checks patterns, verifies cwd
+   * containment, and resolves the sandbox plan. Pure: no side effects,
+   * no spawn. Both {@link execute} (buffered) and {@link stream} (SSE)
+   * call this first so there is a single source of truth for what a
+   * given `args` payload means. If you add a rule, add it here.
+   *
+   * Does NOT throw for blocked patterns — returns a structured
+   * `{ ok: false, code: 'blocked_pattern' }`. The {@link execute}
+   * wrapper preserves the historical throwing behavior for its
+   * callers; new callers should handle the result directly.
+   */
+  preflight(args: Record<string, unknown>): PreflightResult {
     if (!args.command || typeof args.command !== 'string') {
-      return 'Error: command is required';
+      return { ok: false, reason: 'command is required', code: 'bad_args' };
     }
     const cmd = args.command;
 
     for (const pattern of BLOCKED_PATTERNS) {
       if (pattern.test(cmd)) {
-        throw new Error(`Blocked: "${cmd}" matches a dangerous command pattern.`);
+        return {
+          ok: false,
+          reason: `Blocked: "${cmd}" matches a dangerous command pattern.`,
+          code: 'blocked_pattern',
+        };
       }
     }
 
-    // Security: validate CWD
     const cwd = (args.cwd as string) || this.projectRoot;
-    const projectRoot = this.projectRoot;
-    const cwdSafety = isCwdSafe(cwd, projectRoot);
+    const cwdSafety = isCwdSafe(cwd, this.projectRoot);
     if (!cwdSafety.safe) {
-      return `Error: ${cwdSafety.reason}`;
+      return { ok: false, reason: cwdSafety.reason || 'CWD outside project root', code: 'unsafe_cwd' };
     }
 
-    const timeout = (args.timeout as number) || 180000;
+    const timeoutMs = (args.timeout as number) || 180000;
 
-    // ── v1.7.0: Sandbox routing (v2.1.5: uses PolicyEnforcer for RBAC) ──
-    const enforcer = new PolicyEnforcer(undefined, projectRoot);
+    const enforcer = new PolicyEnforcer(undefined, this.projectRoot);
     const sandboxMode = enforcer.getSandboxMode();
     const useSandbox =
       sandboxMode === 'docker' ||
       (sandboxMode === 'auto' && isDockerAvailable());
 
-    if (useSandbox) {
-      const result = sandboxExec(cmd, projectRoot, {
-        network: enforcer.isNetworkAllowed(),
-        memoryMb: enforcer.getMaxMemoryMb(),
-        timeoutMs: timeout,
+    const safeEnv = { ...process.env };
+    for (const key of FILTERED_ENV_VARS) {
+      delete safeEnv[key];
+    }
+
+    return {
+      ok: true,
+      plan: {
+        cmd,
+        cwd,
+        timeoutMs,
+        useSandbox,
+        sandboxMode,
+        sandboxNetwork: enforcer.isNetworkAllowed(),
+        sandboxMemoryMb: enforcer.getMaxMemoryMb(),
+        safeEnv,
+      },
+    };
+  }
+
+  async execute(args: Record<string, unknown>): Promise<string> {
+    const pre = this.preflight(args);
+    if (!pre.ok) {
+      // Preserve historical behavior of the buffered path: blocked
+      // patterns throw (callers catch and surface); arg/cwd errors
+      // return as `Error: ...` strings.
+      if (pre.code === 'blocked_pattern') {
+        throw new Error(pre.reason);
+      }
+      return `Error: ${pre.reason}`;
+    }
+    return this.runBuffered(pre.plan);
+  }
+
+  /**
+   * Streaming exec. Same {@link preflight} as {@link execute} plus one
+   * fail-closed rule: if policy requires sandbox, we do NOT host-fallback
+   * and we do NOT audit-and-proceed — we throw `sandbox_required`. The
+   * SSE transport cannot satisfy Docker-sandbox semantics, so we refuse
+   * the transport and tell the caller to use the non-streaming runner.
+   *
+   * Caller owns audit: Agent.runStreamingTool writes exec_start before
+   * this returns a stream, and exec_complete after the returned promise
+   * resolves (or exec_error if we throw). Tails are capped at 512 bytes
+   * each and returned in the resolved value.
+   */
+  async stream(
+    args: Record<string, unknown>,
+    events: ExecStreamEvents,
+    opts: { timeoutMs?: number } = {},
+  ): Promise<ExecStreamResult> {
+    const pre = this.preflight(args);
+    if (!pre.ok) {
+      throw new ExecStreamError(pre.reason, pre.code);
+    }
+    // Fail closed only when policy EXPLICITLY requires sandbox
+    // (`sandbox: 'docker'`). Under `auto` the buffered path may sandbox
+    // when Docker is available, but the intent is "prefer sandbox, OK
+    // to host-fallback" — not a hard requirement. Host-streaming under
+    // auto is the same UX as the pre-2026-04-24 behavior and we do NOT
+    // silently downgrade from a hard `docker` requirement.
+    if (pre.plan.sandboxMode === 'docker') {
+      throw new ExecStreamError(
+        'Streaming exec is not supported when policy requires sandbox. Use the non-streaming tool runner.',
+        'sandbox_required',
+      );
+    }
+    return this.runStreaming(pre.plan, events, opts.timeoutMs ?? pre.plan.timeoutMs);
+  }
+
+  /** Buffered runner — used by {@link execute}. Sandbox-aware. */
+  private runBuffered(plan: ExecPlan): string {
+    if (plan.useSandbox) {
+      const result = sandboxExec(plan.cmd, this.projectRoot, {
+        network: plan.sandboxNetwork,
+        memoryMb: plan.sandboxMemoryMb,
+        timeoutMs: plan.timeoutMs,
       });
 
       if (result.sandboxed) {
@@ -144,30 +293,102 @@ export class ExecuteTool implements Tool {
         }
         return `${tag} ${output}`;
       }
-      // Fallthrough: sandboxExec returned sandboxed=false (Docker wasn't available after all)
+      // Sandbox declined at runtime — fall through to host.
     }
 
-    // ── Host execution (existing path) ──
-    const safeEnv = { ...process.env };
-    for (const key of FILTERED_ENV_VARS) {
-      delete safeEnv[key];
-    }
-
-    const tag = useSandbox ? '[host-fallback]' : '[host]';
+    const tag = plan.useSandbox ? '[host-fallback]' : '[host]';
 
     try {
-      const output = execSync(cmd, {
-        cwd,
-        timeout,
+      const output = execSync(plan.cmd, {
+        cwd: plan.cwd,
+        timeout: plan.timeoutMs,
         maxBuffer: 1024 * 1024,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: safeEnv,
+        env: plan.safeEnv,
       });
       return `${tag} ${output || '(no output)'}`;
     } catch (err: unknown) {
       const e = err as { status?: number; stdout?: string; stderr?: string };
       return `${tag} Exit code ${e.status || 1}\nSTDOUT:\n${e.stdout || ''}\nSTDERR:\n${e.stderr || ''}`;
     }
+  }
+
+  /**
+   * Streaming runner — spawns via sh, pipes stdout/stderr through
+   * callbacks, enforces the timeout, captures 512-byte rolling tails
+   * for audit forensics.
+   */
+  private runStreaming(
+    plan: ExecPlan,
+    events: ExecStreamEvents,
+    timeoutMs: number,
+  ): Promise<ExecStreamResult> {
+    return new Promise<ExecStreamResult>((resolve, reject) => {
+      let settled = false;
+      const stdoutChunks: string[] = [];
+      const stderrChunks: string[] = [];
+      let stdoutLen = 0;
+      let stderrLen = 0;
+
+      // Rolling tail — keep only the final STREAM_TAIL_MAX bytes of each stream.
+      const pushBounded = (buf: string[], incoming: string, currentLen: number): number => {
+        buf.push(incoming);
+        let total = currentLen + incoming.length;
+        while (total > STREAM_TAIL_MAX * 2 && buf.length > 1) {
+          total -= buf.shift()!.length;
+        }
+        return total;
+      };
+
+      let child;
+      try {
+        child = spawn('sh', ['-c', plan.cmd], { cwd: plan.cwd, env: plan.safeEnv });
+      } catch (err) {
+        reject(new ExecStreamError((err as Error).message || 'spawn failed', 'spawn_error'));
+        return;
+      }
+
+      const timer = setTimeout(() => {
+        if (!child.killed) child.kill('SIGTERM');
+      }, timeoutMs);
+      let timedOut = false;
+      timer.unref?.();
+      const armTimeoutFlag = setTimeout(() => { timedOut = true; }, timeoutMs);
+      armTimeoutFlag.unref?.();
+
+      child.stdout.on('data', (d: Buffer) => {
+        const text = d.toString('utf-8');
+        stdoutLen = pushBounded(stdoutChunks, text, stdoutLen);
+        try { events.onStdout?.(text); } catch { /* consumer errors must not kill the stream */ }
+      });
+
+      child.stderr.on('data', (d: Buffer) => {
+        const text = d.toString('utf-8');
+        stderrLen = pushBounded(stderrChunks, text, stderrLen);
+        try { events.onStderr?.(text); } catch { /* ditto */ }
+      });
+
+      child.on('error', (err: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        clearTimeout(armTimeoutFlag);
+        reject(new ExecStreamError(err.message || 'spawn failed', 'spawn_error'));
+      });
+
+      child.on('close', (code: number | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        clearTimeout(armTimeoutFlag);
+        resolve({
+          exitCode: code ?? (timedOut ? 124 : 0),
+          stdoutTail: clampTail(stdoutChunks),
+          stderrTail: clampTail(stderrChunks),
+          timedOut,
+        });
+      });
+    });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,24 @@ export interface ToolResult {
   is_error?: boolean;
 }
 
+/**
+ * Optional callbacks for streaming-capable tools. Tools that implement
+ * `stream()` emit stdout/stderr chunks through these callbacks instead
+ * of buffering. Transport-agnostic by design — an HTTP/SSE bridge lives
+ * in the caller, not the tool.
+ */
+export interface ToolStreamEvents {
+  onStdout?: (text: string) => void;
+  onStderr?: (text: string) => void;
+}
+
+export interface ToolStreamResult {
+  exitCode: number;
+  stdoutTail: string;
+  stderrTail: string;
+  timedOut: boolean;
+}
+
 export interface Tool {
   name: string;
   description: string;
@@ -34,6 +52,17 @@ export interface Tool {
   permission: 'auto' | 'prompt' | 'always-ask';
   cacheable?: boolean;
   execute(args: Record<string, unknown>): Promise<string>;
+  /**
+   * Optional streaming entry point. Implementers MUST re-run the same
+   * preflight/validation as `execute()` inside `stream()` — the caller's
+   * gate chain runs first, but the tool must defend itself independently
+   * against the "gated, then walked around the fence" pattern.
+   */
+  stream?(
+    args: Record<string, unknown>,
+    events: ToolStreamEvents,
+    opts?: { timeoutMs?: number },
+  ): Promise<ToolStreamResult>;
 }
 
 export interface ProviderConfig {


### PR DESCRIPTION
## Summary
Row 2 follow-up to #13. The streaming exec endpoint still spawned raw `child_process` after a single inline regex check, skipping the agent's policy allow-list, risk scoring, CORD, SPARK, capability, permission, and audit gates. This PR routes it through the same gate chain as every other tool call.

Review round 2 (15cdc89) closed two additional holes caught in review: the streaming path was skipping the fine-grained capability check, and the inline BLOCKED_PATTERNS 403 was unaudited in agent-backed mode.

## What changed
- **`ExecuteTool` refactored** into a shared pipeline:
  - `preflight(args)` — pure validation (arg shape, `BLOCKED_PATTERNS`, cwd containment, sandbox-mode resolution). Returns an `ExecPlan` or typed rejection `{code, reason}`.
  - `execute(args)` — `preflight → runBuffered(plan)`. Preserves the historical throw-vs-return contract for `blocked_pattern`.
  - `stream(args, events, opts)` — `preflight → runStreaming(plan)`. Fails closed with `sandbox_required` (→ HTTP 501) **only** when `sandboxMode === 'docker'` (the explicit require). `'auto'` is prefer-sandbox, host-fallback permitted for streaming.

- **`Agent.runStreamingTool`** — new gated streaming entry point:
  - runs the full gate chain via `_prepareToolCall`
  - runs `checkToolCapabilities(toolName, args)` — the same fine-grained gate the buffered path uses (execute.shell_commands, fs_write globs, net_access domains). On block: audits `capability_block`, increments `security_blocks_total{type:capability}`, returns `{blocked:true, errorCode:'capability_block'}`. Previously skipped on the streaming path, which let disallowed command prefixes stream through /api/command/exec.
  - writes `exec_start` as explicit allow evidence (the gate chain itself only audits blocks today)
  - writes `exec_complete` with exit code + **512-byte** stdout/stderr tails on success
  - writes `exec_error` with code + message on throw

- **`POST /api/command/exec`** — rewritten to call `agent.runStreamingTool('execute', …)`. Standalone mode (`agent=null`) keeps its prior behavior and announces itself with init `{mode:'standalone', guarded:false}`. Inline `BLOCKED_PATTERNS` kept as belt-and-suspenders, and in agent-backed mode now writes a `policy_block` audit entry before returning 403 so the "blocked and audited" claim is actually true on this code path.

- **`Tool` interface** — optional `stream(args, events, opts?)` added. No impact on existing implementers.

- **`AuditLogger`** — action union extended with `exec_start | exec_complete | exec_error`.

## Acceptance tests (`src/dashboard/exec-gate.test.ts`)
Seven tests cover the approved design plus the round-2 review blockers:
1. dangerous command blocked (403), **writes `policy_block` audit entry with the attempted command**, no stdout
2. safe command streams stdout + exit 0, audits `exec_start` + `exec_complete` with tail
3. cwd outside project blocked with `unsafe_cwd` + `exec_error`
4. `sandbox:'docker'` policy returns **501** + `exec_error('sandbox_required')`, no host spawn
5. `agent=null` still streams with `guarded:false` and keeps regex block
6. `ExecuteTool.preflight` parity with `execute()` for accept/reject
7. **(new)** fine-grained capability gate — policy `shell_commands: ['echo']` lets `echo capability-allowed` stream with exit 0, blocks `ls /tmp` with a `blocked` SSE event, audits `capability_block`, no stdout, no exit event, and no `exec_start` (allow evidence must not precede a block)

## Verification
- 7/7 exec-gate tests pass
- 79/79 dashboard + execute suite pass
- 45/45 agent + capabilities suite pass
- `tsc --noEmit` clean

## Test plan
- [x] exec-gate suite: `npx tsx --test src/dashboard/exec-gate.test.ts`
- [x] dashboard + execute suites: `npx tsx --test src/dashboard/*.test.ts src/tools/execute.test.ts`
- [x] agent + capabilities suites: `npx tsx --test src/agent.test.ts src/agent/vault-prompt.test.ts src/capabilities.test.ts`
- [x] typecheck: `npx tsc --noEmit`
- [ ] CI: Security Tests green; full CI only showing known pre-existing failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)