### PR TITLE
[SECURITY] Close shell-injection in test_runner filter/path/cwd

### DIFF
--- a/src/tools/test-runner.test.ts
+++ b/src/tools/test-runner.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TestRunnerTool } from './test-runner';
+
+/**
+ * TestRunnerTool — injection and containment tests.
+ *
+ * Row 10 fix (2026-04-24): `runTests` used to assemble the framework
+ * command by string concatenation and hand it to `execSync`, which
+ * invokes `sh -c <cmd>` on Unix and `cmd.exe /d /s /c <cmd>` on Windows.
+ * Agent-supplied `filter` and `path` went through raw, so
+ *   `filter = '" && touch <marker> #'`
+ * would execute the `touch` branch. These tests pin the argv-based fix
+ * in place and fail loudly if anyone ever reverts to string interpolation.
+ */
+
+describe('TestRunnerTool — metadata', () => {
+  const tool = new TestRunnerTool();
+
+  it('has the expected tool name', () => {
+    assert.strictEqual(tool.name, 'test_runner');
+  });
+
+  it('gates runs behind a user prompt', () => {
+    assert.strictEqual(tool.permission, 'prompt');
+  });
+});
+
+describe('TestRunnerTool — cwd containment', () => {
+  const tool = new TestRunnerTool();
+
+  it('rejects cwd that resolves outside the process root', async () => {
+    // Use the real filesystem root — guaranteed outside process.cwd().
+    const escapeTarget = process.platform === 'win32' ? 'C:\\' : '/etc';
+    const result = await tool.execute({ action: 'detect', cwd: escapeTarget });
+    assert.ok(
+      result.startsWith('Error: cwd escapes project root'),
+      `expected rejection, got: ${result}`,
+    );
+  });
+
+  it('rejects parent-traversal cwd via ../', async () => {
+    const result = await tool.execute({ action: 'detect', cwd: '../..' });
+    assert.ok(
+      result.startsWith('Error: cwd escapes project root'),
+      `expected rejection, got: ${result}`,
+    );
+  });
+
+  it('accepts cwd that resolves inside the process root', async () => {
+    // process.cwd() itself is trivially inside process.cwd().
+    const result = await tool.execute({ action: 'detect', cwd: process.cwd() });
+    assert.ok(
+      !result.startsWith('Error: cwd escapes project root'),
+      `expected accept, got: ${result}`,
+    );
+  });
+});
+
+/**
+ * Real integration test. We build a tiny fake jest project in an
+ * isolated tmpdir, drive the tool with a filter that would spawn a
+ * subprocess if — and only if — the shell interpreted it. Then we
+ * assert the marker file never materialized.
+ *
+ * This is the canary. If a future refactor re-introduces string
+ * interpolation, this test starts failing: the marker appears.
+ */
+describe('TestRunnerTool — shell-injection canary (real exec)', () => {
+  let workDir: string;
+  let originalCwd: string;
+  let markerPath: string;
+
+  before(() => {
+    originalCwd = process.cwd();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row10-'));
+    markerPath = path.join(workDir, 'PWNED');
+
+    // Fake jest project. Script is the classifier — detect() will see
+    // `jest` in scripts.test and pick the safe argv {command:'npx', args:['jest']}.
+    fs.writeFileSync(
+      path.join(workDir, 'package.json'),
+      JSON.stringify({ name: 'row10-canary', scripts: { test: 'jest' } }, null, 2),
+    );
+
+    // Process cwd must be INSIDE or EQUAL to the workDir for cwd
+    // containment to accept it. We chdir in for the duration of the test.
+    process.chdir(workDir);
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    // Best-effort cleanup.
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('does not execute shell metacharacters in filter (the Row 10 bug)', async () => {
+    const tool = new TestRunnerTool();
+    const maliciousFilter = `" && node -e "require('fs').writeFileSync('${markerPath.replace(/\\/g, '\\\\')}', 'pwned')" #`;
+
+    // The tool WILL try to run `npx jest -t <filter>`, which will almost
+    // certainly fail (no jest installed in the tmpdir, no tests, etc.).
+    // We don't care — we care whether the shell interpreted the filter.
+    await tool.execute({ action: 'run', cwd: workDir, filter: maliciousFilter });
+
+    // The canary: if interpolation happened, the `node -e` branch ran and
+    // created the marker. If argv isolation is intact, jest just sees the
+    // filter as a literal test-name pattern and the marker never exists.
+    assert.strictEqual(
+      fs.existsSync(markerPath),
+      false,
+      `SHELL INJECTION REGRESSION: marker ${markerPath} was created, meaning the filter was interpreted by a shell. The tool is back to concatenating into execSync.`,
+    );
+  });
+
+  it('does not execute shell metacharacters in path (target)', async () => {
+    const tool = new TestRunnerTool();
+    const marker2 = path.join(workDir, 'PWNED2');
+    const maliciousPath = `some/test.js; node -e "require('fs').writeFileSync('${marker2.replace(/\\/g, '\\\\')}', 'pwned')"`;
+
+    await tool.execute({ action: 'run', cwd: workDir, path: maliciousPath });
+
+    assert.strictEqual(
+      fs.existsSync(marker2),
+      false,
+      `SHELL INJECTION REGRESSION: marker ${marker2} was created via path arg.`,
+    );
+  });
+});
+
+/**
+ * Argv-shape tests. We call `buildCommand()` directly — it returns the
+ * planned (command, argv) without executing — and pin the contract. If
+ * anyone reverts to string interpolation or re-introduces raw
+ * `pkg.scripts.test` copying, these fail loudly.
+ *
+ * We don't stub execFileSync (child_process exports are read-only getters
+ * in modern Node, and the tool holds a direct reference from its own
+ * import anyway). buildCommand() is the seam.
+ */
+describe('TestRunnerTool — argv shape (via buildCommand)', () => {
+  let workDir: string;
+
+  before(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row10-argv-'));
+    fs.writeFileSync(
+      path.join(workDir, 'package.json'),
+      JSON.stringify({ name: 'row10-argv', scripts: { test: 'jest' } }, null, 2),
+    );
+  });
+
+  after(() => {
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('passes filter as a single argv element, never interpolated', () => {
+    const tool = new TestRunnerTool();
+    const payload = '" && touch /tmp/should-not-happen #';
+    const plan = tool.buildCommand(workDir, { action: 'run', filter: payload });
+
+    assert.ok(!('error' in plan), `expected plan, got error: ${'error' in plan ? plan.error : ''}`);
+    if ('error' in plan) return;
+
+    assert.strictEqual(plan.command, 'npx');
+    assert.deepStrictEqual(plan.argv, ['jest', '-t', payload]);
+    // No element in argv should be a pre-quoted shell fragment.
+    assert.ok(
+      !plan.argv.some((a) => a.includes('-t "')),
+      'filter must be its own argv element, not pre-quoted into a single string',
+    );
+  });
+
+  it('passes target as a single argv element, resolved absolute, contained to cwd', () => {
+    const tool = new TestRunnerTool();
+    const plan = tool.buildCommand(workDir, { action: 'run', path: 'some/test.js' });
+
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.strictEqual(plan.command, 'npx');
+    assert.strictEqual(plan.argv[0], 'jest');
+    assert.strictEqual(plan.argv[1], path.resolve(workDir, 'some/test.js'));
+  });
+
+  it('rejects target that resolves outside cwd (no exec planned)', () => {
+    const tool = new TestRunnerTool();
+    const plan = tool.buildCommand(workDir, { action: 'run', path: '../../../etc/passwd' });
+
+    assert.ok('error' in plan);
+    if ('error' in plan) {
+      assert.ok(plan.error.startsWith('Error: test path escapes cwd'));
+    }
+  });
+
+  it('rejects target that is a sibling-prefix of cwd (not true containment)', () => {
+    // Classic startsWith bug: /tmp/foo vs /tmp/foobar. path.relative catches
+    // it; startsWith(root + sep) would too, but startsWith(root) alone would not.
+    const tool = new TestRunnerTool();
+    const sibling = workDir + '-evil'; // same prefix, different directory
+    const plan = tool.buildCommand(workDir, { action: 'run', path: sibling });
+
+    assert.ok('error' in plan, 'sibling-prefix target must be rejected');
+    if ('error' in plan) {
+      assert.ok(plan.error.startsWith('Error: test path escapes cwd'));
+    }
+  });
+
+  it('never copies pkg.scripts.test verbatim into argv (malicious script fixture)', () => {
+    // Rewrite package.json with a malicious script. detect() uses
+    // scripts.test only as a classifier. The hardcoded argv table must
+    // still be what actually runs — the raw string must NOT appear.
+    const malWorkDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row10-mal-'));
+    try {
+      fs.writeFileSync(
+        path.join(malWorkDir, 'package.json'),
+        JSON.stringify({
+          name: 'row10-malicious',
+          scripts: { test: 'node --test && rm -rf ~' },
+        }, null, 2),
+      );
+
+      const tool = new TestRunnerTool();
+      const plan = tool.buildCommand(malWorkDir, { action: 'run' });
+
+      assert.ok(!('error' in plan), 'expected a plan, not an error');
+      if ('error' in plan) return;
+
+      const flat = [plan.command, ...plan.argv].join(' ');
+      assert.ok(!flat.includes('rm -rf'), `argv must not contain raw scripts.test fragments — got: ${flat}`);
+      assert.ok(!flat.includes('&&'), `argv must not contain shell operators from scripts.test — got: ${flat}`);
+      // The classifier saw 'node --test' and should have picked node:test,
+      // which we execute via ['npm', ['test']] — npm is the binary, not our
+      // shell. Confirm the shape.
+      assert.strictEqual(plan.command, 'npm');
+      assert.deepStrictEqual(plan.argv, ['test']);
+    } finally {
+      try { fs.rmSync(malWorkDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+});

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -1,12 +1,37 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Tool } from '../types';
 
+/**
+ * Framework descriptor. `command` + `args` are executed via execFileSync
+ * (no shell). No user/agent/repo input is ever concatenated into a shell
+ * string — that's how filter/path injection got in pre-2026-04-24.
+ */
 interface FrameworkInfo {
   name: string;
   command: string;
+  args: string[];
   filePattern: string;
+}
+
+/**
+ * Decide whether `target` is contained within `root`.
+ *
+ * Uses path.relative rather than startsWith to avoid the sibling-prefix
+ * trap where `/tmp/project2` passes a `startsWith('/tmp/project')` check.
+ *
+ * Returns true iff target === root OR target lives under root.
+ */
+function isContained(root: string, target: string): boolean {
+  const absRoot = path.resolve(root);
+  const absTarget = path.resolve(target);
+  if (absRoot === absTarget) return true;
+  const rel = path.relative(absRoot, absTarget);
+  if (!rel) return true;
+  if (rel.startsWith('..')) return false;
+  if (path.isAbsolute(rel)) return false;
+  return true;
 }
 
 export class TestRunnerTool implements Tool {
@@ -19,7 +44,7 @@ export class TestRunnerTool implements Tool {
       action: { type: 'string', description: 'Action: run, detect, list' },
       path: { type: 'string', description: 'Test file or directory (defaults to project root)' },
       filter: { type: 'string', description: 'Test name filter / grep pattern' },
-      cwd: { type: 'string', description: 'Working directory' },
+      cwd: { type: 'string', description: 'Working directory (must be inside the process cwd)' },
     },
     required: ['action'],
   };
@@ -28,7 +53,20 @@ export class TestRunnerTool implements Tool {
     const action = args.action as string;
     if (!action) return 'Error: action is required';
 
-    const cwd = (args.cwd as string) || process.cwd();
+    // cwd containment. If the caller passes a cwd, it must be within the
+    // process cwd. We never clamp silently — we reject. This matches the
+    // streaming exec gate's behavior.
+    const processRoot = process.cwd();
+    let cwd: string;
+    if (typeof args.cwd === 'string' && args.cwd.length > 0) {
+      const resolved = path.resolve(processRoot, args.cwd);
+      if (!isContained(processRoot, resolved)) {
+        return `Error: cwd escapes project root (${resolved} not under ${processRoot})`;
+      }
+      cwd = resolved;
+    } else {
+      cwd = processRoot;
+    }
 
     switch (action) {
       case 'detect': return this.detectFramework(cwd);
@@ -41,11 +79,11 @@ export class TestRunnerTool implements Tool {
   private detectFramework(cwd: string): string {
     const fw = this.detect(cwd);
     if (!fw) return 'No test framework detected. Checked for: jest, vitest, mocha, node:test, pytest, go test, cargo test.';
-    return `Detected: ${fw.name}\nCommand: ${fw.command}\nTest files: ${fw.filePattern}`;
+    const shown = [fw.command, ...fw.args].join(' ');
+    return `Detected: ${fw.name}\nCommand: ${shown}\nTest files: ${fw.filePattern}`;
   }
 
   private listTestFiles(cwd: string): string {
-    const patterns = ['**/*.test.*', '**/*.spec.*', '**/test_*.py', '**/*_test.go', '**/tests/**'];
     const files: string[] = [];
     const skip = new Set(['node_modules', '.git', 'dist', 'build', 'coverage']);
 
@@ -54,39 +92,73 @@ export class TestRunnerTool implements Tool {
     return `Test files (${files.length}):\n${files.map(f => `  ${f}`).join('\n')}`;
   }
 
-  private runTests(cwd: string, args: Record<string, unknown>): string {
+  /**
+   * Exposed for tests: build the (command, argv) pair without executing.
+   * Returns either the planned exec OR an error string. Keeping this pure
+   * lets tests pin the argv shape without having to stub child_process
+   * (whose exports are read-only getters in modern Node).
+   */
+  public buildCommand(
+    cwd: string,
+    args: Record<string, unknown>,
+  ): { command: string; argv: string[]; framework: string } | { error: string } {
     const fw = this.detect(cwd);
-    if (!fw) return 'Error: no test framework detected';
+    if (!fw) return { error: 'Error: no test framework detected' };
 
-    let cmd = fw.command;
-    const target = args.path as string;
-    const filter = args.filter as string;
+    // Build argv by pushing string elements. execFileSync does NOT invoke a
+    // shell — metacharacters inside any element stay literal.
+    const argv: string[] = [...fw.args];
 
-    if (target) cmd += ` ${target}`;
-    if (filter) {
-      if (fw.name.includes('jest') || fw.name.includes('vitest')) cmd += ` -t "${filter}"`;
-      else if (fw.name === 'pytest') cmd += ` -k "${filter}"`;
-      else if (fw.name === 'go test') cmd += ` -run "${filter}"`;
+    const target = args.path;
+    if (typeof target === 'string' && target.length > 0) {
+      const resolved = path.resolve(cwd, target);
+      if (!isContained(cwd, resolved)) {
+        return { error: `Error: test path escapes cwd (${resolved} not under ${cwd})` };
+      }
+      argv.push(resolved);
     }
 
+    const filter = args.filter;
+    if (typeof filter === 'string' && filter.length > 0) {
+      if (fw.name === 'jest' || fw.name === 'vitest') argv.push('-t', filter);
+      else if (fw.name === 'pytest') argv.push('-k', filter);
+      else if (fw.name === 'go test') argv.push('-run', filter);
+      // Other frameworks ignore the filter rather than try to guess a syntax.
+    }
+
+    return { command: fw.command, argv, framework: fw.name };
+  }
+
+  private runTests(cwd: string, args: Record<string, unknown>): string {
+    const plan = this.buildCommand(cwd, args);
+    if ('error' in plan) return plan.error;
+
     try {
-      const output = execSync(cmd, {
+      const output = execFileSync(plan.command, plan.argv, {
         cwd,
         timeout: 120_000,
         maxBuffer: 2 * 1024 * 1024,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
       });
-      return this.summarize(output, fw.name);
+      return this.summarize(output, plan.framework);
     } catch (err: unknown) {
       const e = err as { status?: number; stdout?: string; stderr?: string };
       const combined = `${e.stdout || ''}\n${e.stderr || ''}`.trim();
-      return `Tests failed (exit ${e.status || 1}):\n${this.summarize(combined, fw.name)}`;
+      return `Tests failed (exit ${e.status || 1}):\n${this.summarize(combined, plan.framework)}`;
     }
   }
 
   private detect(cwd: string): FrameworkInfo | null {
-    // Check package.json for JS/TS projects
+    // Check package.json for JS/TS projects.
+    //
+    // IMPORTANT: we never copy `pkg.scripts.test` verbatim into the exec
+    // argv. A malicious package.json with `"test": "node --test && rm -rf ~"`
+    // would otherwise be pasted straight into our shell call. Instead, we
+    // use scripts.test only as a *classifier* to pick a known-good argv,
+    // then defer to `npm test` if the project's own script is what the
+    // user actually wants run — that's npm's trust boundary with the
+    // package.json, not ours.
     const pkgPath = path.join(cwd, 'package.json');
     if (fs.existsSync(pkgPath)) {
       try {
@@ -94,38 +166,39 @@ export class TestRunnerTool implements Tool {
         const scripts = pkg.scripts || {};
         const deps = { ...pkg.dependencies, ...pkg.devDependencies };
 
-        if (scripts.test) {
-          if (scripts.test.includes('vitest')) return { name: 'vitest', command: 'npx vitest run', filePattern: '*.test.ts' };
-          if (scripts.test.includes('jest')) return { name: 'jest', command: 'npx jest', filePattern: '*.test.ts' };
-          if (scripts.test.includes('mocha')) return { name: 'mocha', command: 'npx mocha', filePattern: '*.test.ts' };
-          if (scripts.test.includes('node --test')) return { name: 'node:test', command: scripts.test, filePattern: '*.test.ts' };
-          // Generic npm test
-          return { name: 'npm test', command: 'npm test', filePattern: '*.test.*' };
+        if (typeof scripts.test === 'string') {
+          if (scripts.test.includes('vitest')) return { name: 'vitest', command: 'npx', args: ['vitest', 'run'], filePattern: '*.test.ts' };
+          if (scripts.test.includes('jest')) return { name: 'jest', command: 'npx', args: ['jest'], filePattern: '*.test.ts' };
+          if (scripts.test.includes('mocha')) return { name: 'mocha', command: 'npx', args: ['mocha'], filePattern: '*.test.ts' };
+          if (scripts.test.includes('node --test')) return { name: 'node:test', command: 'npm', args: ['test'], filePattern: '*.test.*' };
+          // Generic npm test — let npm itself handle scripts.test. We do
+          // NOT paste scripts.test into our argv.
+          return { name: 'npm test', command: 'npm', args: ['test'], filePattern: '*.test.*' };
         }
-        if (deps['vitest']) return { name: 'vitest', command: 'npx vitest run', filePattern: '*.test.ts' };
-        if (deps['jest']) return { name: 'jest', command: 'npx jest', filePattern: '*.test.ts' };
+        if (deps['vitest']) return { name: 'vitest', command: 'npx', args: ['vitest', 'run'], filePattern: '*.test.ts' };
+        if (deps['jest']) return { name: 'jest', command: 'npx', args: ['jest'], filePattern: '*.test.ts' };
       } catch { /* invalid package.json */ }
     }
 
     // Python
     if (fs.existsSync(path.join(cwd, 'pytest.ini')) || fs.existsSync(path.join(cwd, 'setup.py')) || fs.existsSync(path.join(cwd, 'pyproject.toml'))) {
-      return { name: 'pytest', command: 'python -m pytest -v', filePattern: 'test_*.py' };
+      return { name: 'pytest', command: 'python', args: ['-m', 'pytest', '-v'], filePattern: 'test_*.py' };
     }
 
     // Go
     if (fs.existsSync(path.join(cwd, 'go.mod'))) {
-      return { name: 'go test', command: 'go test ./...', filePattern: '*_test.go' };
+      return { name: 'go test', command: 'go', args: ['test', './...'], filePattern: '*_test.go' };
     }
 
     // Rust
     if (fs.existsSync(path.join(cwd, 'Cargo.toml'))) {
-      return { name: 'cargo test', command: 'cargo test', filePattern: '*.rs' };
+      return { name: 'cargo test', command: 'cargo', args: ['test'], filePattern: '*.rs' };
     }
 
     return null;
   }
 
-  private summarize(output: string, framework: string): string {
+  private summarize(output: string, _framework: string): string {
     const lines = output.split('\n');
     const summary: string[] = [];
 


### PR DESCRIPTION
## Summary

- `TestRunnerTool` used `execSync(string)` with agent-supplied `filter` / `path` concatenated in — same shell-injection class as Rows 9 / 12. A filter like `'\" && node -e \"...\" #'` broke out of the quote and executed the second branch.
- Switched to `execFileSync(command, argv)`. No shell involved; metacharacters inside argv elements stay literal.
- Hardened `cwd` / `path` containment using `path.relative` (not `startsWith`) — closes the `/tmp/foo` vs `/tmp/foo-evil` sibling-prefix trap. Reject on escape, never clamp silently.
- `pkg.scripts.test` is now used **only as a classifier** to pick a known-good argv table. A malicious script like `\"test\": \"node --test && rm -rf ~\"` classifies as `node:test` and executes via `['npm', ['test']]` — npm is the trust boundary with `package.json`, not us.

## Design

- Extracted a pure `buildCommand(cwd, args)` seam returning `{ command, argv, framework } | { error }` without executing. Tests pin the argv contract without stubbing `child_process` (whose exports are read-only getters in modern Node).
- Added `isContained(root, target)` helper using `path.relative` + `rel.startsWith('..') || path.isAbsolute(rel)` check.

## Test plan

- [x] `npm run build` clean
- [x] `node --test dist/tools/test-runner.test.js` — **12/12 pass**
  - 2 canary real-exec tests: build a fake jest project in `fs.mkdtempSync(os.tmpdir(), ...)`, drive with a malicious filter / path that would create a marker file if interpreted by a shell, assert marker never appears. If a future refactor reverts to interpolation, these fail loudly.
  - Argv-shape tests: filter is its own argv element, target resolves absolute & contained, escape rejected, sibling-prefix rejected, malicious `scripts.test` never copied into argv.
  - cwd-containment tests: rejects `/etc`, rejects `../..`, accepts `process.cwd()`.
- [x] Scope: `src/tools/test-runner.ts` + `src/tools/test-runner.test.ts` only.
- [x] 3 pre-existing `anthropic.test.ts` failures in the full suite were baseline-verified on `main` — not a Row 10 regression. Tracked in Issue #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)