### PR TITLE
[SECURITY] Close shell-injection in graphics tool

### DIFF
--- a/src/tools/graphics.test.ts
+++ b/src/tools/graphics.test.ts
@@ -3,120 +3,571 @@ import * as assert from 'node:assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { GraphicsTool } from './graphics';
+import { GraphicsTool, __resetMagickCache } from './graphics';
 
-describe('GraphicsTool', () => {
+/**
+ * GraphicsTool — injection, containment, and validation tests (Row 12).
+ *
+ * Pre-fix, every exec sink used execSync(string) with user-supplied paths,
+ * format, numeric dimensions, and watermark text pasted straight in. A
+ * malicious `output = 'x"; touch /tmp/pwned; echo "'` broke out of the
+ * quote and executed the second branch.
+ *
+ * These tests pin the argv-based fix:
+ *   - buildMagickPlan() returns argv as a real array; filter/text/path are
+ *     single elements, never pre-quoted shell fragments
+ *   - containment rejects anything outside process.cwd()
+ *   - invalid hex colors return errors (no silent fallback)
+ *   - numeric validation catches non-finite / string / negative inputs
+ *   - canary real-exec tests assert no marker file ever materializes
+ */
+
+describe('GraphicsTool — metadata', () => {
   const tool = new GraphicsTool();
-  const tmpDir = path.join(os.tmpdir(), 'codebot-graphics-test-' + Date.now());
 
-  before(() => {
-    fs.mkdirSync(tmpDir, { recursive: true });
-  });
-
-  after(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  it('has correct metadata', () => {
+  it('has the expected tool name', () => {
     assert.strictEqual(tool.name, 'graphics');
+  });
+
+  it('gates runs behind a user prompt', () => {
     assert.strictEqual(tool.permission, 'prompt');
-    assert.ok(tool.description.includes('SVG'));
   });
 
   it('returns error for unknown action', async () => {
     const result = await tool.execute({ action: 'explode' });
     assert.ok(result.includes('Error: unknown action'));
   });
+});
 
-  it('svg action creates SVG icon', async () => {
-    const output = path.join(tmpDir, 'test-icon.svg');
+/**
+ * Argv-shape tests. We call buildMagickPlan() directly — it returns the
+ * planned (backend, argv) without executing. If anyone reverts to string
+ * interpolation, these fail loudly.
+ */
+describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
+  let workDir: string;
+  let originalCwd: string;
+
+  before(() => {
+    __resetMagickCache();
+    originalCwd = process.cwd();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row12-argv-'));
+    process.chdir(workDir);
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('resize: input/output resolved absolute, geometry built from validated ints', () => {
+    const tool = new GraphicsTool();
+    fs.writeFileSync(path.join(workDir, 'in.png'), 'not-a-real-png');
+    const plan = tool.buildMagickPlan('resize',
+      { action: 'resize', input: 'in.png', width: 100, height: 50, output: 'out.png' },
+      workDir,
+    );
+    assert.ok(!('error' in plan), `expected plan, got: ${'error' in plan ? plan.error : ''}`);
+    if ('error' in plan) return;
+
+    // argv must be an array of discrete elements. No '"' in any element.
+    for (const el of plan.argv) {
+      assert.ok(!el.includes('"'), `argv element should have no embedded quote: ${el}`);
+    }
+    if (plan.backend === 'magick') {
+      assert.deepStrictEqual(plan.argv, [
+        path.resolve(workDir, 'in.png'),
+        '-resize', '100x50!',
+        path.resolve(workDir, 'out.png'),
+      ]);
+    } else {
+      // sips fallback on darwin when magick is absent — still argv-shaped.
+      assert.strictEqual(plan.argv[0], '-z');
+      assert.strictEqual(plan.argv[1], '50');
+      assert.strictEqual(plan.argv[2], '100');
+      assert.strictEqual(plan.argv[3], path.resolve(workDir, 'out.png'));
+    }
+  });
+
+  it('resize: rejects string "100; rm -rf ~" as width', () => {
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('resize',
+      { action: 'resize', input: 'in.png', width: '100; rm -rf ~', output: 'out.png' },
+      workDir,
+    );
+    assert.ok('error' in plan);
+    if ('error' in plan) {
+      assert.match(plan.error, /width must be a finite integer/);
+    }
+  });
+
+  it('resize: rejects output that escapes cwd', () => {
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('resize',
+      { action: 'resize', input: 'in.png', width: 50, output: '../../etc/passwd' },
+      workDir,
+    );
+    assert.ok('error' in plan);
+    if ('error' in plan) {
+      assert.match(plan.error, /output escapes project root/);
+    }
+  });
+
+  it('resize: rejects sibling-prefix output (not true containment)', () => {
+    // Classic startsWith bug: workDir + '-evil' shares a prefix but is a
+    // different directory. path.relative catches it.
+    const tool = new GraphicsTool();
+    const sibling = workDir + '-evil';
+    const plan = tool.buildMagickPlan('resize',
+      { action: 'resize', input: 'in.png', width: 50, output: sibling },
+      workDir,
+    );
+    assert.ok('error' in plan, 'sibling-prefix must be rejected');
+    if ('error' in plan) {
+      assert.match(plan.error, /output escapes project root/);
+    }
+  });
+
+  it('watermark: text is one argv element, never pre-quoted', () => {
+    const tool = new GraphicsTool();
+    const payload = 'hi"; touch /tmp/should-not-happen; echo "';
+    const plan = tool.buildMagickPlan('watermark',
+      { action: 'watermark', input: 'in.png', text: payload, output: 'wm.png' },
+      workDir,
+    );
+    if ('error' in plan) {
+      // If magick isn't installed, watermark refuses. That's fine — skip.
+      assert.match(plan.error, /ImageMagick not found|input|text/);
+      return;
+    }
+    // The exact malicious string must appear as ONE argv element, unmodified.
+    assert.ok(plan.argv.includes(payload),
+      `text must be its own argv element; got argv: ${JSON.stringify(plan.argv)}`);
+    // No element should contain the shell-injection continuation.
+    assert.ok(!plan.argv.some(a => a.startsWith('-annotate +') && a.includes(';')),
+      'text must NOT be pre-joined into a flag argument');
+    // -annotate must be its own element, followed by '+10+10', then the text.
+    const annotateIdx = plan.argv.indexOf('-annotate');
+    assert.ok(annotateIdx >= 0);
+    assert.strictEqual(plan.argv[annotateIdx + 1], '+10+10');
+    assert.strictEqual(plan.argv[annotateIdx + 2], payload);
+  });
+
+  it('crop: validates width/height/x/y as non-negative finite ints', () => {
+    const tool = new GraphicsTool();
+    fs.writeFileSync(path.join(workDir, 'cr.png'), 'x');
+    const plan = tool.buildMagickPlan('crop',
+      { action: 'crop', input: 'cr.png', width: 100, height: 50, x: 10, y: 20, output: 'cr-out.png' },
+      workDir,
+    );
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    if (plan.backend === 'magick') {
+      assert.deepStrictEqual(plan.argv, [
+        path.resolve(workDir, 'cr.png'),
+        '-crop', '100x50+10+20',
+        '+repage',
+        path.resolve(workDir, 'cr-out.png'),
+      ]);
+    } else {
+      // sips: -c H W --cropOffset Y X out
+      assert.deepStrictEqual(plan.argv, [
+        '-c', '50', '100',
+        '--cropOffset', '20', '10',
+        path.resolve(workDir, 'cr-out.png'),
+      ]);
+    }
+  });
+
+  it('crop: rejects malicious width string', () => {
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('crop',
+      { action: 'crop', input: 'cr.png', width: '100; touch /tmp/pwned;#', height: 50 },
+      workDir,
+    );
+    assert.ok('error' in plan);
+    if ('error' in plan) assert.match(plan.error, /width must be a finite integer/);
+  });
+
+  it('convert: rejects malicious format string', () => {
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('convert',
+      { action: 'convert', input: 'in.png', format: 'jpg; ls' },
+      workDir,
+    );
+    assert.ok('error' in plan);
+    if ('error' in plan) assert.match(plan.error, /format must be one of/);
+  });
+
+  it('convert: accepts the allowed format list', () => {
+    const tool = new GraphicsTool();
+    for (const fmt of ['png', 'jpg', 'jpeg', 'webp', 'gif', 'svg', 'ico']) {
+      const plan = tool.buildMagickPlan('convert',
+        { action: 'convert', input: 'in.png', format: fmt, output: `out.${fmt}` },
+        workDir,
+      );
+      assert.ok(!('error' in plan), `format ${fmt} must be accepted; got ${'error' in plan ? plan.error : ''}`);
+    }
+  });
+
+  it('info: input must be inside cwd (no /etc read primitive)', () => {
+    const tool = new GraphicsTool();
+    const escapeTarget = process.platform === 'win32' ? 'C:\\Windows\\win.ini' : '/etc/passwd';
+    const plan = tool.buildMagickPlan('info',
+      { action: 'info', input: escapeTarget },
+      workDir,
+    );
+    assert.ok('error' in plan);
+    if ('error' in plan) assert.match(plan.error, /input escapes project root/);
+  });
+
+  it('info: argv uses identify -verbose, no shell pipe', () => {
+    const tool = new GraphicsTool();
+    fs.writeFileSync(path.join(workDir, 'it.png'), 'x');
+    const plan = tool.buildMagickPlan('info',
+      { action: 'info', input: 'it.png' },
+      workDir,
+    );
+    if ('error' in plan) {
+      // No magick AND not darwin — tool returns an error. Acceptable.
+      assert.match(plan.error, /no image introspection tool/);
+      return;
+    }
+    if (plan.backend === 'magick') {
+      assert.deepStrictEqual(plan.argv, ['identify', '-verbose', path.resolve(workDir, 'it.png')]);
+    }
+    // No element should contain a shell pipe.
+    assert.ok(!plan.argv.some(a => a.includes('|')),
+      `info argv must not contain shell pipes; got ${JSON.stringify(plan.argv)}`);
+  });
+
+  it('combine: every comma-split input is resolved and contained', () => {
+    const tool = new GraphicsTool();
+    fs.writeFileSync(path.join(workDir, 'a.png'), 'x');
+    fs.writeFileSync(path.join(workDir, 'b.png'), 'x');
+    const plan = tool.buildMagickPlan('combine',
+      { action: 'combine', inputs: 'a.png, b.png', direction: 'horizontal', output: 'ab.png' },
+      workDir,
+    );
+    if ('error' in plan) {
+      // magick missing — skip argv-shape assertion, just ensure the error
+      // is the 'no magick' message, not an injection.
+      assert.match(plan.error, /ImageMagick not found/);
+      return;
+    }
+    assert.deepStrictEqual(plan.argv, [
+      path.resolve(workDir, 'a.png'),
+      path.resolve(workDir, 'b.png'),
+      '+append',
+      path.resolve(workDir, 'ab.png'),
+    ]);
+  });
+
+  it('combine: rejects an input that escapes cwd', () => {
+    const tool = new GraphicsTool();
+    const escapeTarget = process.platform === 'win32' ? 'C:\\Windows\\win.ini' : '/etc/passwd';
+    const plan = tool.buildMagickPlan('combine',
+      { action: 'combine', inputs: `a.png,${escapeTarget}`, output: 'out.png' },
+      workDir,
+    );
+    assert.ok('error' in plan);
+    if ('error' in plan) {
+      // Either "input escapes" OR "magick not found" is acceptable — both
+      // mean no exec happens. Prefer the containment message.
+      assert.ok(
+        /input escapes project root|ImageMagick not found/.test(plan.error),
+        `expected containment or no-magick error, got: ${plan.error}`,
+      );
+    }
+  });
+});
+
+/**
+ * Color/svg validation: hostile hex colors must be rejected, not silently
+ * replaced. Silent fallback hides hostile input in what looks like a
+ * normal SVG — we want a clear error surface.
+ */
+describe('GraphicsTool — color/text validation (svg + og_image)', () => {
+  let workDir: string;
+  let originalCwd: string;
+
+  before(() => {
+    originalCwd = process.cwd();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row12-color-'));
+    process.chdir(workDir);
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('svg: rejects non-hex bg_color (no silent fallback)', async () => {
+    const tool = new GraphicsTool();
     const result = await tool.execute({
       action: 'svg',
       svg_type: 'icon',
       text: 'CB',
-      output,
+      bg_color: '"/><script>alert(1)</script><rect fill="',
+      output: 'icon.svg',
     });
-    assert.ok(result.includes('SVG'));
-    assert.ok(result.includes(output));
-    assert.ok(fs.existsSync(output));
-    const content = fs.readFileSync(output, 'utf-8');
+    assert.match(result, /bg_color must be a hex color/);
+    assert.ok(!fs.existsSync(path.join(workDir, 'icon.svg')),
+      'no file should be written when validation fails');
+  });
+
+  it('svg: rejects non-hex accent_color', async () => {
+    const tool = new GraphicsTool();
+    const result = await tool.execute({
+      action: 'svg',
+      svg_type: 'logo',
+      text: 'AI',
+      accent_color: 'red',
+      output: 'logo.svg',
+    });
+    assert.match(result, /accent_color must be a hex color/);
+  });
+
+  it('og_image: rejects non-hex bg_color', async () => {
+    const tool = new GraphicsTool();
+    const result = await tool.execute({
+      action: 'og_image',
+      title: 'Hi',
+      bg_color: 'not-a-color',
+      output: 'og.svg',
+    });
+    assert.match(result, /bg_color must be a hex color/);
+  });
+
+  it('svg: text with XML metacharacters is escaped into the document', async () => {
+    const tool = new GraphicsTool();
+    const result = await tool.execute({
+      action: 'svg',
+      svg_type: 'icon',
+      text: '</text><script>alert(1)</script>',
+      output: 'hostile.svg',
+    });
+    assert.match(result, /SVG \(icon\) saved/);
+    const written = fs.readFileSync(path.join(workDir, 'hostile.svg'), 'utf-8');
+    assert.ok(!written.includes('<script>'),
+      `SVG must not contain raw <script>; got: ${written}`);
+    assert.ok(written.includes('&lt;script&gt;'),
+      'SVG text must be XML-escaped');
+  });
+
+  it('svg_content (raw): output outside cwd is rejected', async () => {
+    const tool = new GraphicsTool();
+    const escapeTarget = process.platform === 'win32' ? 'C:\\Windows\\evil.svg' : '/etc/cron.d/evil';
+    const result = await tool.execute({
+      action: 'svg',
+      svg_content: '<svg/>',
+      output: escapeTarget,
+    });
+    assert.match(result, /output escapes project root/);
+    assert.ok(!fs.existsSync(escapeTarget));
+  });
+});
+
+/**
+ * Canary real-exec tests. Even if ImageMagick/sips aren't installed on
+ * the test host, the code path reaches the exec call and errors via
+ * ENOENT — a shell is NEVER spawned. So the marker file stays absent
+ * either way. If a future refactor re-introduces execSync(string), the
+ * malicious output/text breaks out and the marker appears → test fails.
+ */
+describe('GraphicsTool — shell-injection canaries (real exec)', () => {
+  let workDir: string;
+  let originalCwd: string;
+
+  before(() => {
+    originalCwd = process.cwd();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row12-canary-'));
+    process.chdir(workDir);
+    // Write a non-empty file where the tool expects a real image. Magick
+    // will error on the content; we don't care — only about the shell.
+    fs.writeFileSync(path.join(workDir, 'in.png'), 'not-a-real-png');
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('resize/output: shell metacharacters in output are NEVER interpreted', async () => {
+    const marker = path.join(workDir, 'PWNED_RESIZE');
+    const tool = new GraphicsTool();
+    const malicious = `${path.join(workDir, 'out.png')}"; node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')" #`;
+
+    await tool.execute({
+      action: 'resize',
+      input: 'in.png',
+      width: 10,
+      output: malicious,
+    });
+
+    assert.strictEqual(
+      fs.existsSync(marker),
+      false,
+      `SHELL INJECTION REGRESSION: ${marker} was created via output. Tool is back to concatenating into execSync.`,
+    );
+  });
+
+  it('watermark/text: shell metacharacters in text are NEVER interpreted', async () => {
+    const marker = path.join(workDir, 'PWNED_WATERMARK');
+    const tool = new GraphicsTool();
+    const maliciousText = `hi"; node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')" #`;
+
+    await tool.execute({
+      action: 'watermark',
+      input: 'in.png',
+      text: maliciousText,
+      output: 'wm.png',
+    });
+
+    assert.strictEqual(
+      fs.existsSync(marker),
+      false,
+      `SHELL INJECTION REGRESSION: ${marker} was created via watermark text.`,
+    );
+  });
+
+  it('combine/output: shell metacharacters in output are NEVER interpreted', async () => {
+    const marker = path.join(workDir, 'PWNED_COMBINE');
+    const tool = new GraphicsTool();
+    fs.writeFileSync(path.join(workDir, 'c1.png'), 'x');
+    fs.writeFileSync(path.join(workDir, 'c2.png'), 'x');
+    const malicious = `${path.join(workDir, 'out.png')}"; node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')" #`;
+
+    await tool.execute({
+      action: 'combine',
+      inputs: 'c1.png,c2.png',
+      output: malicious,
+    });
+
+    assert.strictEqual(
+      fs.existsSync(marker),
+      false,
+      `SHELL INJECTION REGRESSION: ${marker} was created via combine output.`,
+    );
+  });
+
+  it('convert/format: shell metacharacters in format are NEVER interpreted', async () => {
+    const marker = path.join(workDir, 'PWNED_CONVERT');
+    const tool = new GraphicsTool();
+    // Even if this reaches sips on macOS, the format is validated against
+    // a whitelist before any exec, so it should bounce with the format
+    // error. The canary asserts no shell ran.
+    await tool.execute({
+      action: 'convert',
+      input: 'in.png',
+      format: `png; node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')" #`,
+    });
+
+    assert.strictEqual(
+      fs.existsSync(marker),
+      false,
+      `SHELL INJECTION REGRESSION: ${marker} was created via format.`,
+    );
+  });
+});
+
+/**
+ * Happy-path regression: the non-exec actions (svg, og_image) still work
+ * end-to-end. These mirror the previous test file so we know we didn't
+ * break legitimate usage.
+ */
+describe('GraphicsTool — happy-path regression', () => {
+  let workDir: string;
+  let originalCwd: string;
+
+  before(() => {
+    originalCwd = process.cwd();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row12-happy-'));
+    process.chdir(workDir);
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('svg action creates SVG icon with escaped text', async () => {
+    const tool = new GraphicsTool();
+    const result = await tool.execute({
+      action: 'svg',
+      svg_type: 'icon',
+      text: 'CB',
+      output: 'icon.svg',
+    });
+    assert.match(result, /SVG/);
+    const full = path.resolve(workDir, 'icon.svg');
+    assert.ok(fs.existsSync(full));
+    const content = fs.readFileSync(full, 'utf-8');
     assert.ok(content.includes('<svg'));
     assert.ok(content.includes('CB'));
   });
 
-  it('svg action creates badge', async () => {
-    const output = path.join(tmpDir, 'test-badge.svg');
+  it('svg action creates badge with valid color', async () => {
+    const tool = new GraphicsTool();
     const result = await tool.execute({
       action: 'svg',
       svg_type: 'badge',
       text: 'v2.5',
-      output,
+      bg_color: '#123456',
+      output: 'badge.svg',
     });
-    assert.ok(result.includes('SVG'));
-    assert.ok(fs.existsSync(output));
+    assert.match(result, /SVG/);
+    const content = fs.readFileSync(path.resolve(workDir, 'badge.svg'), 'utf-8');
+    assert.ok(content.includes('#123456'));
   });
 
-  it('svg action creates logo', async () => {
-    const output = path.join(tmpDir, 'test-logo.svg');
+  it('svg action creates logo with valid accent color', async () => {
+    const tool = new GraphicsTool();
     const result = await tool.execute({
       action: 'svg',
       svg_type: 'logo',
       text: 'AI',
       accent_color: '#ff6b6b',
-      output,
+      output: 'logo.svg',
     });
-    assert.ok(result.includes('SVG'));
-    assert.ok(fs.existsSync(output));
-    const content = fs.readFileSync(output, 'utf-8');
+    assert.match(result, /SVG/);
+    const content = fs.readFileSync(path.resolve(workDir, 'logo.svg'), 'utf-8');
     assert.ok(content.includes('#ff6b6b'));
   });
 
-  it('svg action saves raw SVG content', async () => {
-    const output = path.join(tmpDir, 'test-raw.svg');
+  it('svg action saves raw svg_content inside cwd', async () => {
+    const tool = new GraphicsTool();
     const svgContent = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="red"/></svg>';
     const result = await tool.execute({
       action: 'svg',
       svg_content: svgContent,
-      output,
+      output: 'raw.svg',
     });
-    assert.ok(result.includes('SVG saved'));
-    assert.strictEqual(fs.readFileSync(output, 'utf-8'), svgContent);
+    assert.match(result, /SVG saved/);
+    assert.strictEqual(fs.readFileSync(path.resolve(workDir, 'raw.svg'), 'utf-8'), svgContent);
   });
 
-  it('og_image generates Open Graph image', async () => {
-    const output = path.join(tmpDir, 'og.svg');
+  it('og_image generates Open Graph SVG with escaped title', async () => {
+    const tool = new GraphicsTool();
     const result = await tool.execute({
       action: 'og_image',
-      title: 'CodeBot AI',
+      title: 'CodeBot & <friends>',
       subtitle: 'Your autonomous coding assistant',
-      output,
+      output: 'og.svg',
     });
-    assert.ok(result.includes('OG image'));
-    assert.ok(result.includes('1200x630'));
-    assert.ok(fs.existsSync(output));
-    const content = fs.readFileSync(output, 'utf-8');
-    assert.ok(content.includes('CodeBot AI'));
+    assert.match(result, /OG image/);
+    assert.match(result, /1200x630/);
+    const content = fs.readFileSync(path.resolve(workDir, 'og.svg'), 'utf-8');
+    assert.ok(content.includes('CodeBot'));
+    assert.ok(content.includes('&amp;'), 'ampersand must be XML-escaped');
+    assert.ok(content.includes('&lt;friends&gt;'), 'angle brackets must be XML-escaped');
+    assert.ok(!content.includes('<friends>'));
   });
 
-  it('info requires input path', async () => {
-    const result = await tool.execute({ action: 'info' });
-    assert.ok(result.includes('Error:'));
-  });
-
-  it('resize requires input and dimensions', async () => {
-    const result = await tool.execute({ action: 'resize', input: '/nonexistent.png' });
-    assert.ok(result.includes('Error:'));
-  });
-
-  it('convert requires format', async () => {
-    const result = await tool.execute({ action: 'convert', input: '/nonexistent.png' });
-    assert.ok(result.includes('Error:'));
-  });
-
-  it('crop requires width and height', async () => {
-    const testFile = path.join(tmpDir, 'test.txt');
-    fs.writeFileSync(testFile, 'test');
-    const result = await tool.execute({ action: 'crop', input: testFile });
-    assert.ok(result.includes('Error:'));
+  it('info: missing file returns a clean error, no exec', async () => {
+    const tool = new GraphicsTool();
+    // Path is inside cwd but doesn't exist — containment passes, exists check fails.
+    const result = await tool.execute({ action: 'info', input: 'missing.png' });
+    assert.match(result, /file not found|no image introspection tool/);
   });
 });

--- a/src/tools/graphics.test.ts
+++ b/src/tools/graphics.test.ts
@@ -3,23 +3,25 @@ import * as assert from 'node:assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { GraphicsTool, __resetMagickCache } from './graphics';
+import { GraphicsTool, __resetMagickCache, __setMagickFlavorForTest } from './graphics';
 
 /**
- * GraphicsTool — injection, containment, and validation tests (Row 12).
+ * GraphicsTool — injection, containment, validation, and flavor-aware
+ * planning tests (Row 12).
  *
  * Pre-fix, every exec sink used execSync(string) with user-supplied paths,
  * format, numeric dimensions, and watermark text pasted straight in. A
  * malicious `output = 'x"; touch /tmp/pwned; echo "'` broke out of the
  * quote and executed the second branch.
  *
- * These tests pin the argv-based fix:
- *   - buildMagickPlan() returns argv as a real array; filter/text/path are
- *     single elements, never pre-quoted shell fragments
- *   - containment rejects anything outside process.cwd()
- *   - invalid hex colors return errors (no silent fallback)
- *   - numeric validation catches non-finite / string / negative inputs
- *   - canary real-exec tests assert no marker file ever materializes
+ * These tests pin the argv-based fix plus two post-review patches:
+ *   P2 — plans carry a `command` field. `info` and `combine grid` dispatch
+ *        `identify` / `montage` as their own binaries on ImageMagick v6
+ *        and via `magick <subcmd>` on v7. Pre-patch, v6 hosts silently
+ *        ran `convert identify -verbose <file>`.
+ *   P3 — numeric fields require `typeof v === 'number'`. Strings are
+ *        rejected. Favicon `sizes` is a deliberately-string field and
+ *        uses a separate digits-only parser.
  */
 
 describe('GraphicsTool — metadata', () => {
@@ -41,7 +43,7 @@ describe('GraphicsTool — metadata', () => {
 
 /**
  * Argv-shape tests. We call buildMagickPlan() directly — it returns the
- * planned (backend, argv) without executing. If anyone reverts to string
+ * planned (command, argv) without executing. If anyone reverts to string
  * interpolation, these fail loudly.
  */
 describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
@@ -70,35 +72,62 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
     assert.ok(!('error' in plan), `expected plan, got: ${'error' in plan ? plan.error : ''}`);
     if ('error' in plan) return;
 
-    // argv must be an array of discrete elements. No '"' in any element.
     for (const el of plan.argv) {
       assert.ok(!el.includes('"'), `argv element should have no embedded quote: ${el}`);
     }
     if (plan.backend === 'magick') {
+      // command is 'magick' (v7) or 'convert' (v6). argv shape is identical.
+      assert.ok(['magick', 'convert'].includes(plan.command),
+        `expected magick or convert, got ${plan.command}`);
       assert.deepStrictEqual(plan.argv, [
         path.resolve(workDir, 'in.png'),
         '-resize', '100x50!',
         path.resolve(workDir, 'out.png'),
       ]);
     } else {
-      // sips fallback on darwin when magick is absent — still argv-shaped.
-      assert.strictEqual(plan.argv[0], '-z');
-      assert.strictEqual(plan.argv[1], '50');
-      assert.strictEqual(plan.argv[2], '100');
-      assert.strictEqual(plan.argv[3], path.resolve(workDir, 'out.png'));
+      assert.strictEqual(plan.command, 'sips');
+      assert.deepStrictEqual(plan.argv, [
+        '-z', '50', '100', path.resolve(workDir, 'out.png'),
+      ]);
     }
   });
 
-  it('resize: rejects string "100; rm -rf ~" as width', () => {
+  it('resize: rejects string "100; rm -rf ~" as width (not a number)', () => {
     const tool = new GraphicsTool();
     const plan = tool.buildMagickPlan('resize',
       { action: 'resize', input: 'in.png', width: '100; rm -rf ~', output: 'out.png' },
       workDir,
     );
     assert.ok('error' in plan);
-    if ('error' in plan) {
-      assert.match(plan.error, /width must be a finite integer/);
-    }
+    if ('error' in plan) assert.match(plan.error, /width must be a number/);
+  });
+
+  it('resize: rejects string "100" as width (P3: strict number, no coercion)', () => {
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('resize',
+      { action: 'resize', input: 'in.png', width: '100', height: 50 },
+      workDir,
+    );
+    assert.ok('error' in plan, 'string "100" must be rejected even though it parses to 100');
+    if ('error' in plan) assert.match(plan.error, /width must be a number/);
+  });
+
+  it('resize: rejects "1e3" as width (P3: no exponential coercion)', () => {
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('resize',
+      { action: 'resize', input: 'in.png', width: '1e3', height: 50 },
+      workDir,
+    );
+    assert.ok('error' in plan);
+  });
+
+  it('resize: rejects non-integer number as width', () => {
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('resize',
+      { action: 'resize', input: 'in.png', width: 100.5, height: 50 },
+      workDir,
+    );
+    assert.ok('error' in plan);
   });
 
   it('resize: rejects output that escapes cwd', () => {
@@ -108,14 +137,10 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
       workDir,
     );
     assert.ok('error' in plan);
-    if ('error' in plan) {
-      assert.match(plan.error, /output escapes project root/);
-    }
+    if ('error' in plan) assert.match(plan.error, /output escapes project root/);
   });
 
   it('resize: rejects sibling-prefix output (not true containment)', () => {
-    // Classic startsWith bug: workDir + '-evil' shares a prefix but is a
-    // different directory. path.relative catches it.
     const tool = new GraphicsTool();
     const sibling = workDir + '-evil';
     const plan = tool.buildMagickPlan('resize',
@@ -123,9 +148,7 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
       workDir,
     );
     assert.ok('error' in plan, 'sibling-prefix must be rejected');
-    if ('error' in plan) {
-      assert.match(plan.error, /output escapes project root/);
-    }
+    if ('error' in plan) assert.match(plan.error, /output escapes project root/);
   });
 
   it('watermark: text is one argv element, never pre-quoted', () => {
@@ -136,17 +159,13 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
       workDir,
     );
     if ('error' in plan) {
-      // If magick isn't installed, watermark refuses. That's fine — skip.
       assert.match(plan.error, /ImageMagick not found|input|text/);
       return;
     }
-    // The exact malicious string must appear as ONE argv element, unmodified.
     assert.ok(plan.argv.includes(payload),
       `text must be its own argv element; got argv: ${JSON.stringify(plan.argv)}`);
-    // No element should contain the shell-injection continuation.
     assert.ok(!plan.argv.some(a => a.startsWith('-annotate +') && a.includes(';')),
       'text must NOT be pre-joined into a flag argument');
-    // -annotate must be its own element, followed by '+10+10', then the text.
     const annotateIdx = plan.argv.indexOf('-annotate');
     assert.ok(annotateIdx >= 0);
     assert.strictEqual(plan.argv[annotateIdx + 1], '+10+10');
@@ -170,7 +189,6 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
         path.resolve(workDir, 'cr-out.png'),
       ]);
     } else {
-      // sips: -c H W --cropOffset Y X out
       assert.deepStrictEqual(plan.argv, [
         '-c', '50', '100',
         '--cropOffset', '20', '10',
@@ -186,7 +204,7 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
       workDir,
     );
     assert.ok('error' in plan);
-    if ('error' in plan) assert.match(plan.error, /width must be a finite integer/);
+    if ('error' in plan) assert.match(plan.error, /width must be a number/);
   });
 
   it('convert: rejects malicious format string', () => {
@@ -221,26 +239,6 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
     if ('error' in plan) assert.match(plan.error, /input escapes project root/);
   });
 
-  it('info: argv uses identify -verbose, no shell pipe', () => {
-    const tool = new GraphicsTool();
-    fs.writeFileSync(path.join(workDir, 'it.png'), 'x');
-    const plan = tool.buildMagickPlan('info',
-      { action: 'info', input: 'it.png' },
-      workDir,
-    );
-    if ('error' in plan) {
-      // No magick AND not darwin — tool returns an error. Acceptable.
-      assert.match(plan.error, /no image introspection tool/);
-      return;
-    }
-    if (plan.backend === 'magick') {
-      assert.deepStrictEqual(plan.argv, ['identify', '-verbose', path.resolve(workDir, 'it.png')]);
-    }
-    // No element should contain a shell pipe.
-    assert.ok(!plan.argv.some(a => a.includes('|')),
-      `info argv must not contain shell pipes; got ${JSON.stringify(plan.argv)}`);
-  });
-
   it('combine: every comma-split input is resolved and contained', () => {
     const tool = new GraphicsTool();
     fs.writeFileSync(path.join(workDir, 'a.png'), 'x');
@@ -250,11 +248,10 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
       workDir,
     );
     if ('error' in plan) {
-      // magick missing — skip argv-shape assertion, just ensure the error
-      // is the 'no magick' message, not an injection.
       assert.match(plan.error, /ImageMagick not found/);
       return;
     }
+    assert.ok(['magick', 'convert'].includes(plan.command));
     assert.deepStrictEqual(plan.argv, [
       path.resolve(workDir, 'a.png'),
       path.resolve(workDir, 'b.png'),
@@ -272,8 +269,6 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
     );
     assert.ok('error' in plan);
     if ('error' in plan) {
-      // Either "input escapes" OR "magick not found" is acceptable — both
-      // mean no exec happens. Prefer the containment message.
       assert.ok(
         /input escapes project root|ImageMagick not found/.test(plan.error),
         `expected containment or no-magick error, got: ${plan.error}`,
@@ -283,9 +278,161 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
 });
 
 /**
+ * P2 — flavor-aware planning. Under ImageMagick v7, `info` dispatches via
+ * `magick identify …` and `combine grid` via `magick montage …`. Under
+ * v6, those are their own binaries — plans must carry `command:
+ * 'identify'` / `command: 'montage'` directly.
+ *
+ * Pre-patch, on a v6 host (only `convert`, `identify`, `montage` installed,
+ * no `magick`), the runner executed `convert identify -verbose <file>` —
+ * silently broken because `convert` doesn't dispatch subcommands.
+ */
+describe('GraphicsTool — flavor-aware planning (P2)', () => {
+  let workDir: string;
+  let originalCwd: string;
+
+  before(() => {
+    originalCwd = process.cwd();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row12-flavor-'));
+    process.chdir(workDir);
+    fs.writeFileSync(path.join(workDir, 'f.png'), 'x');
+    fs.writeFileSync(path.join(workDir, 'a.png'), 'x');
+    fs.writeFileSync(path.join(workDir, 'b.png'), 'x');
+  });
+
+  after(() => {
+    __setMagickFlavorForTest(null);
+    process.chdir(originalCwd);
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('planInfo under v7: command="magick", argv starts with "identify"', () => {
+    __setMagickFlavorForTest('v7');
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('info',
+      { action: 'info', input: 'f.png' }, workDir);
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.strictEqual(plan.command, 'magick');
+    assert.deepStrictEqual(plan.argv, ['identify', '-verbose', path.resolve(workDir, 'f.png')]);
+  });
+
+  it('planInfo under v6: command="identify" directly (not "convert identify")', () => {
+    __setMagickFlavorForTest('v6');
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('info',
+      { action: 'info', input: 'f.png' }, workDir);
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    // This is the P2 fix. Pre-patch, command would have been 'convert' and
+    // argv[0] would have been 'identify' — which breaks on v6 hosts.
+    assert.strictEqual(plan.command, 'identify',
+      'under v6, info MUST exec identify directly, not convert');
+    assert.deepStrictEqual(plan.argv, ['-verbose', path.resolve(workDir, 'f.png')]);
+  });
+
+  it('planCombine grid under v7: command="magick", argv starts with "montage"', () => {
+    __setMagickFlavorForTest('v7');
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('combine',
+      { action: 'combine', inputs: 'a.png,b.png', direction: 'grid', output: 'g.png' },
+      workDir);
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.strictEqual(plan.command, 'magick');
+    assert.strictEqual(plan.argv[0], 'montage');
+  });
+
+  it('planCombine grid under v6: command="montage" directly', () => {
+    __setMagickFlavorForTest('v6');
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('combine',
+      { action: 'combine', inputs: 'a.png,b.png', direction: 'grid', output: 'g.png' },
+      workDir);
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.strictEqual(plan.command, 'montage',
+      'under v6, combine grid MUST exec montage directly');
+    assert.notStrictEqual(plan.argv[0], 'montage',
+      'argv must NOT double-prefix montage when command is already montage');
+  });
+
+  it('planCombine horizontal under v6: command="convert", argv has no subcommand prefix', () => {
+    __setMagickFlavorForTest('v6');
+    const tool = new GraphicsTool();
+    const plan = tool.buildMagickPlan('combine',
+      { action: 'combine', inputs: 'a.png,b.png', direction: 'horizontal', output: 'h.png' },
+      workDir);
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.strictEqual(plan.command, 'convert');
+    assert.deepStrictEqual(plan.argv, [
+      path.resolve(workDir, 'a.png'),
+      path.resolve(workDir, 'b.png'),
+      '+append',
+      path.resolve(workDir, 'h.png'),
+    ]);
+  });
+
+  it('planResize under v7 uses command="magick"; under v6 uses "convert"', () => {
+    const tool = new GraphicsTool();
+
+    __setMagickFlavorForTest('v7');
+    let plan = tool.buildMagickPlan('resize',
+      { action: 'resize', input: 'f.png', width: 32, output: 'o.png' }, workDir);
+    assert.ok(!('error' in plan));
+    if (!('error' in plan)) assert.strictEqual(plan.command, 'magick');
+
+    __setMagickFlavorForTest('v6');
+    plan = tool.buildMagickPlan('resize',
+      { action: 'resize', input: 'f.png', width: 32, output: 'o.png' }, workDir);
+    assert.ok(!('error' in plan));
+    if (!('error' in plan)) assert.strictEqual(plan.command, 'convert');
+  });
+});
+
+/**
+ * Favicon sizes uses a separate string-to-int parser on purpose — that
+ * field is comma-separated by design. Make sure the parser still rejects
+ * anything that isn't pure digits.
+ */
+describe('GraphicsTool — favicon sizes parser (P3 carve-out)', () => {
+  let workDir: string;
+  let originalCwd: string;
+
+  before(() => {
+    originalCwd = process.cwd();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row12-sizes-'));
+    process.chdir(workDir);
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('rejects a non-digit token in sizes', async () => {
+    const tool = new GraphicsTool();
+    fs.writeFileSync(path.join(workDir, 'src.png'), 'x');
+    const result = await tool.execute({
+      action: 'favicon', input: 'src.png', sizes: '16,32,bad',
+    });
+    assert.match(result, /sizes entry "bad" must be a positive integer/);
+  });
+
+  it('rejects "16; ls" injection attempt in sizes', async () => {
+    const tool = new GraphicsTool();
+    fs.writeFileSync(path.join(workDir, 'src.png'), 'x');
+    const result = await tool.execute({
+      action: 'favicon', input: 'src.png', sizes: '16; ls',
+    });
+    assert.match(result, /sizes entry .* must be a positive integer/);
+  });
+});
+
+/**
  * Color/svg validation: hostile hex colors must be rejected, not silently
- * replaced. Silent fallback hides hostile input in what looks like a
- * normal SVG — we want a clear error surface.
+ * replaced.
  */
 describe('GraphicsTool — color/text validation (svg + og_image)', () => {
   let workDir: string;
@@ -383,8 +530,6 @@ describe('GraphicsTool — shell-injection canaries (real exec)', () => {
     originalCwd = process.cwd();
     workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row12-canary-'));
     process.chdir(workDir);
-    // Write a non-empty file where the tool expects a real image. Magick
-    // will error on the content; we don't care — only about the shell.
     fs.writeFileSync(path.join(workDir, 'in.png'), 'not-a-real-png');
   });
 
@@ -454,9 +599,6 @@ describe('GraphicsTool — shell-injection canaries (real exec)', () => {
   it('convert/format: shell metacharacters in format are NEVER interpreted', async () => {
     const marker = path.join(workDir, 'PWNED_CONVERT');
     const tool = new GraphicsTool();
-    // Even if this reaches sips on macOS, the format is validated against
-    // a whitelist before any exec, so it should bounce with the format
-    // error. The canary asserts no shell ran.
     await tool.execute({
       action: 'convert',
       input: 'in.png',
@@ -473,8 +615,7 @@ describe('GraphicsTool — shell-injection canaries (real exec)', () => {
 
 /**
  * Happy-path regression: the non-exec actions (svg, og_image) still work
- * end-to-end. These mirror the previous test file so we know we didn't
- * break legitimate usage.
+ * end-to-end.
  */
 describe('GraphicsTool — happy-path regression', () => {
   let workDir: string;
@@ -566,7 +707,6 @@ describe('GraphicsTool — happy-path regression', () => {
 
   it('info: missing file returns a clean error, no exec', async () => {
     const tool = new GraphicsTool();
-    // Path is inside cwd but doesn't exist — containment passes, exists check fails.
     const result = await tool.execute({ action: 'info', input: 'missing.png' });
     assert.match(result, /file not found|no image introspection tool/);
   });

--- a/src/tools/graphics.test.ts
+++ b/src/tools/graphics.test.ts
@@ -51,13 +51,18 @@ describe('GraphicsTool — argv shape (via buildMagickPlan)', () => {
   let originalCwd: string;
 
   before(() => {
-    __resetMagickCache();
+    // Force v7 flavor so planning hits the magick branch on CI hosts that
+    // don't have ImageMagick installed. These tests are about argv shape,
+    // not about whether the host binary exists; the flavor-aware suite
+    // below exercises v7 vs v6 explicitly.
+    __setMagickFlavorForTest('v7');
     originalCwd = process.cwd();
     workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row12-argv-'));
     process.chdir(workDir);
   });
 
   after(() => {
+    __setMagickFlavorForTest(null);
     process.chdir(originalCwd);
     try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
   });

--- a/src/tools/graphics.ts
+++ b/src/tools/graphics.ts
@@ -13,13 +13,19 @@
  * agent-supplied inputs (paths, text, format, numeric dimensions) pasted
  * straight into the string. That routes through `sh -c` on Unix and
  * `cmd.exe /c` on Windows. A malicious `output = 'x"; touch /tmp/pwned; echo "'`
- * broke out of the quote and executed the `touch` branch. Same bug class
- * as Rows 9, 10 and 12. Agent reached it with a single `prompt`-tier
- * approval — a one-click RCE primitive.
+ * broke out of the quote and executed the `touch` branch.
  *
  * This file now:
  *   - Uses `execFileSync(cmd, argv)`. No shell involved.
- *   - Validates numeric dimensions, colors, and format against whitelists.
+ *   - Uses a plan shape `{ command, argv }` that names the actual binary to
+ *     exec. Handles ImageMagick v7 (`magick <subcmd>`) and v6
+ *     (`identify`, `montage`) correctly — pre-patch, info/combine-grid
+ *     silently invoked `convert identify …` on v6 hosts.
+ *   - Strict numeric validation — `typeof v === 'number'` is required for
+ *     width/height/quality/x/y. No implicit string-to-number coercion.
+ *     Favicon `sizes` is intentionally a string field and uses a separate
+ *     digits-only parser.
+ *   - Validates colors / format against whitelists.
  *   - Contains every input/output/derived path under `process.cwd()` using
  *     `path.relative` (sibling-prefix safe).
  *   - Exposes `buildMagickPlan()` — a pure seam that returns the planned
@@ -70,14 +76,34 @@ function resolveInside(root: string, p: string, label: string):
 // ─── Validators ─────────────────────────────────────────────────────────────
 
 /**
- * Validate a value is a finite non-negative integer. TypeScript's `as number`
- * cast is erased at runtime — the agent can still send a string. Guard here.
+ * Strict numeric validator. The agent can send anything the JSON schema
+ * says is a number — but wire-format JSON strings still reach us as
+ * strings at the TS level (`as number` is erased). Reject non-numbers
+ * outright. Favicon `sizes` is a string field by design; it uses
+ * `parseSizeToken` below.
  */
 function validateInt(v: unknown, name: string, min = 0, max = 100_000):
   { n: number } | { error: string } {
-  const n = typeof v === 'number' ? v : Number(v);
+  if (typeof v !== 'number' || !Number.isFinite(v) || !Number.isInteger(v) || v < min || v > max) {
+    return { error: `Error: ${name} must be a number (integer in [${min}, ${max}])` };
+  }
+  return { n: v };
+}
+
+/**
+ * Parse a single token from a comma-separated sizes string. Accepts only
+ * decimal digits — no '1e3', no '0x10', no '100; ls'. Kept separate from
+ * validateInt() because `sizes` is intentionally a string parameter.
+ */
+function parseSizeToken(raw: string, min = 1, max = 2048):
+  { n: number } | { error: string } {
+  const s = raw.trim();
+  if (!/^\d+$/.test(s)) {
+    return { error: `Error: sizes entry "${raw}" must be a positive integer` };
+  }
+  const n = Number(s);
   if (!Number.isFinite(n) || !Number.isInteger(n) || n < min || n > max) {
-    return { error: `Error: ${name} must be a finite integer in [${min}, ${max}]` };
+    return { error: `Error: sizes entry "${raw}" must be an integer in [${min}, ${max}]` };
   }
   return { n };
 }
@@ -106,65 +132,85 @@ function validateHexColor(v: unknown, name: string):
 }
 
 // ─── ImageMagick probe (cached) ─────────────────────────────────────────────
+//
+// Flavors:
+//   'v7'  — `magick` binary present. Use `magick` for convert-style ops and
+//           `magick identify` / `magick montage` for subcommands.
+//   'v6'  — legacy `convert`, `identify`, `montage` as separate binaries.
+//   null  — no ImageMagick. Fall back to sips where possible.
+//
+// Pre-patch bug: the old code called `convert identify -verbose …` on v6
+// hosts because plans carried only argv and the runner re-used the
+// convert-style command. Plans now carry the actual executable.
 
-/**
- * Probe once, cache forever. Expanding the probe into every action call
- * would make the tool flaky and slow. A process-lifetime cache is fine
- * because the binary state doesn't change mid-run.
- */
-let _magickCache: { present: boolean; cmd: 'magick' | 'convert' | null } | null = null;
+type MagickFlavor = 'v7' | 'v6' | null;
 
-function probeMagick(): { present: boolean; cmd: 'magick' | 'convert' | null } {
+let _magickCache: { flavor: MagickFlavor } | null = null;
+
+function probeMagick(): { flavor: MagickFlavor } {
   if (_magickCache !== null) return _magickCache;
   try {
     execFileSync('magick', ['--version'], { stdio: 'pipe', timeout: 5_000 });
-    _magickCache = { present: true, cmd: 'magick' };
+    _magickCache = { flavor: 'v7' };
     return _magickCache;
   } catch { /* fall through */ }
   try {
     execFileSync('convert', ['--version'], { stdio: 'pipe', timeout: 5_000 });
-    _magickCache = { present: true, cmd: 'convert' };
+    _magickCache = { flavor: 'v6' };
     return _magickCache;
   } catch { /* fall through */ }
-  _magickCache = { present: false, cmd: null };
+  _magickCache = { flavor: null };
   return _magickCache;
 }
 
-function hasMagick(): boolean { return probeMagick().present; }
-function magickCmd(): string { return probeMagick().cmd ?? 'magick'; }
+function hasMagick(): boolean { return probeMagick().flavor !== null; }
+
+/** The convert-style command: `magick` on v7, `convert` on v6. */
+function magickConvertCmd(): string {
+  return probeMagick().flavor === 'v7' ? 'magick' : 'convert';
+}
+
+/**
+ * Build the leading tokens for a magick subcommand (identify, montage).
+ * On v7 this is `magick <sub> …`. On v6 the subcommand is its own binary.
+ * Returned as `{ command, prefix }` so plans can splat prefix into argv.
+ */
+function magickSubcommand(sub: 'identify' | 'montage'):
+  { command: string; prefix: string[] } {
+  if (probeMagick().flavor === 'v7') return { command: 'magick', prefix: [sub] };
+  return { command: sub, prefix: [] };
+}
 
 /** Reset the magick probe cache. Exposed for tests only. */
 export function __resetMagickCache(): void { _magickCache = null; }
 
+/**
+ * Test-only: override the magick probe result. Lets tests exercise v7 and
+ * v6 planning branches without depending on what's installed on the host.
+ * Pass `null` to clear and let the real probe run next time.
+ */
+export function __setMagickFlavorForTest(flavor: MagickFlavor): void {
+  if (flavor === null) { _magickCache = null; return; }
+  _magickCache = { flavor };
+}
+
 // ─── Exec helpers ───────────────────────────────────────────────────────────
 
 /**
- * Run magick/convert with an argv array. No shell. Metacharacters inside
- * argv elements stay literal.
+ * Execute a planned command. Plan's `command` names the actual executable
+ * (e.g. 'magick', 'convert', 'identify', 'montage'). No shell involved;
+ * metacharacters inside argv stay literal.
  */
-function runMagickArgv(argv: string[]): string {
+function runPlan(command: string, argv: string[], label: 'magick' | 'sips'): string {
   try {
-    return execFileSync(magickCmd(), argv, {
+    return execFileSync(command, argv, {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 30_000,
       maxBuffer: 10 * 1024 * 1024,
     }).toString().trim();
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`ImageMagick error: ${msg.substring(0, 200)}`);
-  }
-}
-
-/** Run sips with an argv array. No shell. */
-function runSipsArgv(argv: string[]): string {
-  try {
-    return execFileSync('sips', argv, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 30_000,
-    }).toString().trim();
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`sips error: ${msg.substring(0, 200)}`);
+    throw new Error(`${label === 'sips' ? 'sips' : 'ImageMagick'} error: ${msg.substring(0, 200)}`);
   }
 }
 
@@ -195,8 +241,8 @@ function escapeXml(str: string): string {
 // ─── Plan type exported for tests ───────────────────────────────────────────
 
 export type MagickPlan =
-  | { backend: 'magick'; argv: string[] }
-  | { backend: 'sips'; argv: string[] }
+  | { backend: 'magick'; command: string; argv: string[] }
+  | { backend: 'sips'; command: 'sips'; argv: string[] }
   | { error: string };
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -262,7 +308,7 @@ export class GraphicsTool implements Tool {
   }
 
   /**
-   * Pure seam for tests. Returns the planned (backend, argv) without
+   * Pure seam for tests. Returns the planned (command, argv) without
    * executing. Lets tests pin the argv contract and catch regressions to
    * string interpolation without stubbing child_process (whose exports are
    * read-only getters in modern Node).
@@ -320,16 +366,19 @@ export class GraphicsTool implements Tool {
     if ('error' in outRes) return outRes;
 
     if (hasMagick()) {
-      return { backend: 'magick', argv: [inRes.resolved, '-resize', geometry, outRes.resolved] };
+      return {
+        backend: 'magick',
+        command: magickConvertCmd(),
+        argv: [inRes.resolved, '-resize', geometry, outRes.resolved],
+      };
     }
     if (os.platform() === 'darwin') {
-      // sips modifies in place. The wrapper (runTests-style) copies first.
       const sipsArgv = w !== null && h !== null
         ? ['-z', String(h), String(w), outRes.resolved]
         : w !== null
           ? ['--resampleWidth', String(w), outRes.resolved]
           : ['--resampleHeight', String(h), outRes.resolved];
-      return { backend: 'sips', argv: sipsArgv };
+      return { backend: 'sips', command: 'sips', argv: sipsArgv };
     }
     return { error: 'Error: ImageMagick not found. Install with: brew install imagemagick (macOS) or apt install imagemagick (Linux)' };
   }
@@ -339,17 +388,14 @@ export class GraphicsTool implements Tool {
     if ('error' in plan) return plan.error;
     try {
       if (plan.backend === 'sips') {
-        // Derive the resolved input/output from the plan's last arg.
         const outPath = plan.argv[plan.argv.length - 1];
-        // Re-resolve input (it's not in the sips argv; pull from args).
-        const inputArg = args.input as string;
-        const inputResolved = path.resolve(process.cwd(), inputArg);
+        const inputResolved = path.resolve(process.cwd(), args.input as string);
         fs.copyFileSync(inputResolved, outPath);
-        runSipsArgv(plan.argv);
+        runPlan(plan.command, plan.argv, 'sips');
         const stats = fs.statSync(outPath);
         return `Resized → ${outPath} (${(stats.size / 1024).toFixed(1)}KB)`;
       }
-      runMagickArgv(plan.argv);
+      runPlan(plan.command, plan.argv, 'magick');
       const outPath = plan.argv[plan.argv.length - 1];
       const stats = fs.statSync(outPath);
       const geometry = plan.argv[plan.argv.indexOf('-resize') + 1];
@@ -384,12 +430,19 @@ export class GraphicsTool implements Tool {
     }
 
     if (hasMagick()) {
-      return { backend: 'magick', argv: [inRes.resolved, ...qualityArgs, outRes.resolved] };
+      return {
+        backend: 'magick',
+        command: magickConvertCmd(),
+        argv: [inRes.resolved, ...qualityArgs, outRes.resolved],
+      };
     }
     if (os.platform() === 'darwin') {
-      // sips maps jpg → jpeg.
       const sipsFmt = fmt.ok === 'jpg' ? 'jpeg' : fmt.ok;
-      return { backend: 'sips', argv: ['-s', 'format', sipsFmt, outRes.resolved] };
+      return {
+        backend: 'sips',
+        command: 'sips',
+        argv: ['-s', 'format', sipsFmt, outRes.resolved],
+      };
     }
     return { error: 'Error: ImageMagick not found' };
   }
@@ -402,11 +455,11 @@ export class GraphicsTool implements Tool {
         const outPath = plan.argv[plan.argv.length - 1];
         const inputResolved = path.resolve(process.cwd(), args.input as string);
         fs.copyFileSync(inputResolved, outPath);
-        runSipsArgv(plan.argv);
+        runPlan(plan.command, plan.argv, 'sips');
         const stats = fs.statSync(outPath);
         return `Converted → ${outPath} (${(stats.size / 1024).toFixed(1)}KB)`;
       }
-      runMagickArgv(plan.argv);
+      runPlan(plan.command, plan.argv, 'magick');
       const outPath = plan.argv[plan.argv.length - 1];
       const stats = fs.statSync(outPath);
       return `Converted → ${outPath} (${(stats.size / 1024).toFixed(1)}KB)`;
@@ -435,6 +488,7 @@ export class GraphicsTool implements Tool {
     if (!hasMagick()) return { error: 'Error: ImageMagick not found (needed for compression)' };
     return {
       backend: 'magick',
+      command: magickConvertCmd(),
       argv: [inRes.resolved, '-strip', '-quality', String(q.n), outRes.resolved],
     };
   }
@@ -445,7 +499,7 @@ export class GraphicsTool implements Tool {
     try {
       const inputResolved = path.resolve(process.cwd(), args.input as string);
       const beforeSize = fs.statSync(inputResolved).size;
-      runMagickArgv(plan.argv);
+      runPlan(plan.command, plan.argv, 'magick');
       const outPath = plan.argv[plan.argv.length - 1];
       const afterSize = fs.statSync(outPath).size;
       const qIdx = plan.argv.indexOf('-quality');
@@ -482,11 +536,16 @@ export class GraphicsTool implements Tool {
 
     if (hasMagick()) {
       const geom = `${w.n}x${h.n}+${x.n}+${y.n}`;
-      return { backend: 'magick', argv: [inRes.resolved, '-crop', geom, '+repage', outRes.resolved] };
+      return {
+        backend: 'magick',
+        command: magickConvertCmd(),
+        argv: [inRes.resolved, '-crop', geom, '+repage', outRes.resolved],
+      };
     }
     if (os.platform() === 'darwin') {
       return {
         backend: 'sips',
+        command: 'sips',
         argv: ['-c', String(h.n), String(w.n), '--cropOffset', String(y.n), String(x.n), outRes.resolved],
       };
     }
@@ -501,10 +560,10 @@ export class GraphicsTool implements Tool {
         const outPath = plan.argv[plan.argv.length - 1];
         const inputResolved = path.resolve(process.cwd(), args.input as string);
         fs.copyFileSync(inputResolved, outPath);
-        runSipsArgv(plan.argv);
+        runPlan(plan.command, plan.argv, 'sips');
         return `Cropped → ${outPath}`;
       }
-      runMagickArgv(plan.argv);
+      runPlan(plan.command, plan.argv, 'magick');
       const outPath = plan.argv[plan.argv.length - 1];
       const geom = plan.argv[plan.argv.indexOf('-crop') + 1];
       return `Cropped ${geom} → ${outPath}`;
@@ -539,11 +598,9 @@ export class GraphicsTool implements Tool {
     };
     const gravity = gravityMap[position] ?? 'SouthEast';
 
-    // `text` is one argv element. Magick `-annotate` consumes it as the
-    // literal annotation string; shell metacharacters inside never reach
-    // any shell.
     return {
       backend: 'magick',
+      command: magickConvertCmd(),
       argv: [
         inRes.resolved,
         '-gravity', gravity,
@@ -559,7 +616,7 @@ export class GraphicsTool implements Tool {
     const plan = this.planWatermark(args, process.cwd());
     if ('error' in plan) return plan.error;
     try {
-      runMagickArgv(plan.argv);
+      runPlan(plan.command, plan.argv, 'magick');
       const outPath = plan.argv[plan.argv.length - 1];
       const gravity = plan.argv[plan.argv.indexOf('-gravity') + 1];
       return `Watermarked (${gravity}) → ${outPath}`;
@@ -578,11 +635,20 @@ export class GraphicsTool implements Tool {
     if ('error' in inRes) return inRes;
 
     if (hasMagick()) {
-      return { backend: 'magick', argv: ['identify', '-verbose', inRes.resolved] };
+      // v7: `magick identify -verbose <file>`; v6: `identify -verbose <file>`.
+      // Pre-patch, this ran `convert identify -verbose <file>` on v6 hosts
+      // — silently broken.
+      const sub = magickSubcommand('identify');
+      return {
+        backend: 'magick',
+        command: sub.command,
+        argv: [...sub.prefix, '-verbose', inRes.resolved],
+      };
     }
     if (os.platform() === 'darwin') {
       return {
         backend: 'sips',
+        command: 'sips',
         argv: ['-g', 'pixelWidth', '-g', 'pixelHeight', '-g', 'format', inRes.resolved],
       };
     }
@@ -590,8 +656,6 @@ export class GraphicsTool implements Tool {
   }
 
   private info(args: Record<string, unknown>): string {
-    // `info` wants filesystem metadata even if magick/sips aren't installed.
-    // We still validate & contain the path via the plan.
     const plan = this.planInfo(args, process.cwd());
     if ('error' in plan) return plan.error;
     const inputResolved = plan.argv[plan.argv.length - 1];
@@ -602,12 +666,7 @@ export class GraphicsTool implements Tool {
     let details = `File: ${inputResolved}\n  Size: ${(stats.size / 1024).toFixed(1)}KB\n  Format: ${ext.slice(1)}`;
 
     try {
-      let raw: string;
-      if (plan.backend === 'magick') {
-        raw = runMagickArgv(plan.argv);
-      } else {
-        raw = runSipsArgv(plan.argv);
-      }
+      const raw = runPlan(plan.command, plan.argv, plan.backend === 'sips' ? 'sips' : 'magick');
       // Row 12 note: the old code piped through `| head -20` via a shell.
       // Replaced with JS slicing — no shell dependency.
       const truncated = raw.split('\n').slice(0, 20).join('\n');
@@ -736,16 +795,19 @@ export class GraphicsTool implements Tool {
     if ('error' in outDirRes) return outDirRes.error;
     const outputDir = outDirRes.resolved;
 
+    // `sizes` is a string-typed field by design (comma-separated). Parse
+    // each token with the strict digits-only validator.
     const sizesStr = typeof args.sizes === 'string' ? args.sizes : '16,32,48,64,128,256';
     const sizes: number[] = [];
     for (const raw of sizesStr.split(',')) {
-      const v = validateInt(raw.trim(), 'sizes entry', 1, 2048);
+      const v = parseSizeToken(raw, 1, 2048);
       if ('error' in v) return v.error;
       sizes.push(v.n);
     }
 
     ensureDir(outputDir);
     const results: string[] = [];
+    const convertCmd = magickConvertCmd();
 
     if (inRes.resolved.endsWith('.svg')) {
       const svgDest = path.join(outputDir, 'favicon.svg');
@@ -756,12 +818,12 @@ export class GraphicsTool implements Tool {
         for (const size of sizes) {
           const pngPath = path.join(outputDir, `favicon-${size}x${size}.png`);
           try {
-            runMagickArgv([
+            runPlan(convertCmd, [
               '-background', 'none', '-density', '300',
               inRes.resolved,
               '-resize', `${size}x${size}`,
               pngPath,
-            ]);
+            ], 'magick');
             results.push(`  ${pngPath} (${size}x${size})`);
           } catch { /* skip failed sizes */ }
         }
@@ -771,7 +833,7 @@ export class GraphicsTool implements Tool {
         if (icoSources.length) {
           const icoPath = path.join(outputDir, 'favicon.ico');
           try {
-            runMagickArgv([...icoSources, icoPath]);
+            runPlan(convertCmd, [...icoSources, icoPath], 'magick');
             results.push(`  ${icoPath} (ICO)`);
           } catch { /* ico generation failed */ }
         }
@@ -788,10 +850,10 @@ export class GraphicsTool implements Tool {
       const pngPath = path.join(outputDir, `favicon-${size}x${size}.png`);
       try {
         if (hasMagick()) {
-          runMagickArgv([inRes.resolved, '-resize', `${size}x${size}`, pngPath]);
+          runPlan(convertCmd, [inRes.resolved, '-resize', `${size}x${size}`, pngPath], 'magick');
         } else {
           fs.copyFileSync(inRes.resolved, pngPath);
-          runSipsArgv(['-z', String(size), String(size), pngPath]);
+          runPlan('sips', ['-z', String(size), String(size), pngPath], 'sips');
         }
         results.push(`  ${pngPath} (${size}x${size})`);
       } catch { /* skip failed sizes */ }
@@ -804,7 +866,7 @@ export class GraphicsTool implements Tool {
       if (icoSources.length) {
         const icoPath = path.join(outputDir, 'favicon.ico');
         try {
-          runMagickArgv([...icoSources, icoPath]);
+          runPlan(convertCmd, [...icoSources, icoPath], 'magick');
           results.push(`  ${icoPath} (ICO)`);
         } catch { /* ico failed */ }
       }
@@ -834,6 +896,7 @@ export class GraphicsTool implements Tool {
     const pngPath = outRes.resolved.replace(/\.svg$/, '.png');
     return {
       backend: 'magick',
+      command: magickConvertCmd(),
       argv: ['-background', 'none', '-density', '150', outRes.resolved, '-resize', '1200x630!', pngPath],
     };
   }
@@ -872,12 +935,12 @@ export class GraphicsTool implements Tool {
     if (hasMagick() && outRes.resolved.endsWith('.svg')) {
       const pngPath = outRes.resolved.replace(/\.svg$/, '.png');
       try {
-        runMagickArgv([
+        runPlan(magickConvertCmd(), [
           '-background', 'none', '-density', '150',
           outRes.resolved,
           '-resize', '1200x630!',
           pngPath,
-        ]);
+        ], 'magick');
         pngNote = `\n  PNG: ${pngPath}`;
       } catch { /* png conversion failed */ }
     }
@@ -915,17 +978,26 @@ export class GraphicsTool implements Tool {
     if ('error' in outRes) return outRes;
 
     if (direction === 'horizontal') {
-      return { backend: 'magick', argv: [...resolved, '+append', outRes.resolved] };
+      return {
+        backend: 'magick',
+        command: magickConvertCmd(),
+        argv: [...resolved, '+append', outRes.resolved],
+      };
     }
     if (direction === 'vertical') {
-      return { backend: 'magick', argv: [...resolved, '-append', outRes.resolved] };
+      return {
+        backend: 'magick',
+        command: magickConvertCmd(),
+        argv: [...resolved, '-append', outRes.resolved],
+      };
     }
-    // grid — use `montage` as the first argv element. Magick dispatches to
-    // the montage tool internally when invoked this way.
+    // grid — v7: `magick montage …`; v6: `montage …` as a separate binary.
     const cols = Math.ceil(Math.sqrt(resolved.length));
+    const sub = magickSubcommand('montage');
     return {
       backend: 'magick',
-      argv: ['montage', ...resolved, '-geometry', '+2+2', '-tile', `${cols}x`, outRes.resolved],
+      command: sub.command,
+      argv: [...sub.prefix, ...resolved, '-geometry', '+2+2', '-tile', `${cols}x`, outRes.resolved],
     };
   }
 
@@ -933,20 +1005,14 @@ export class GraphicsTool implements Tool {
     const plan = this.planCombine(args, process.cwd());
     if ('error' in plan) return plan.error;
     try {
-      // Verify each input file exists (containment already done in the plan).
-      for (const el of plan.argv) {
-        // Only check elements that look like paths (skip the magick flags).
-        if (el.startsWith('+') || el.startsWith('-') || el === 'montage') continue;
-        // Skip tile spec / the output (last).
-        if (/^\d+x$/.test(el)) continue;
-      }
-      runMagickArgv(plan.argv);
+      runPlan(plan.command, plan.argv, 'magick');
       const outPath = plan.argv[plan.argv.length - 1];
       const direction = typeof args.direction === 'string' ? args.direction : 'horizontal';
-      // Count inputs: argv length minus known flag count.
+      // Count inputs: argv elements that aren't flags, aren't the 'montage'
+      // subcommand, aren't tile specs, minus the trailing output.
       const countGuess = plan.argv.filter(a =>
         !a.startsWith('+') && !a.startsWith('-') && a !== 'montage' && !/^\d+x$/.test(a)
-      ).length - 1; // minus the output
+      ).length - 1;
       return `Combined ${countGuess} images (${direction}) → ${outPath}`;
     } catch (err: unknown) {
       return `Error: ${err instanceof Error ? err.message : String(err)}`;

--- a/src/tools/graphics.ts
+++ b/src/tools/graphics.ts
@@ -1,43 +1,150 @@
 /**
- * Graphics Tool — Image processing, SVG generation & asset creation
+ * Graphics Tool — Image processing, SVG generation & asset creation.
  *
- * Uses ImageMagick (convert/magick) when available for raster operations.
- * SVG generation and favicon creation work without external dependencies.
+ * Uses ImageMagick (magick/convert) when available for raster operations,
+ * falls back to macOS `sips` for a subset of actions. SVG generation and
+ * favicon creation from SVG work without any external dependency.
  *
  * Actions: resize, convert, compress, crop, watermark, info,
- *          svg, favicon, og_image, sprite, combine
+ *          svg, favicon, og_image, combine.
+ *
+ * Row 12 fix (2026-04-24):
+ * Pre-fix, every exec sink used `execSync(\`${cmd} ${argsString}\`)` with
+ * agent-supplied inputs (paths, text, format, numeric dimensions) pasted
+ * straight into the string. That routes through `sh -c` on Unix and
+ * `cmd.exe /c` on Windows. A malicious `output = 'x"; touch /tmp/pwned; echo "'`
+ * broke out of the quote and executed the `touch` branch. Same bug class
+ * as Rows 9, 10 and 12. Agent reached it with a single `prompt`-tier
+ * approval — a one-click RCE primitive.
+ *
+ * This file now:
+ *   - Uses `execFileSync(cmd, argv)`. No shell involved.
+ *   - Validates numeric dimensions, colors, and format against whitelists.
+ *   - Contains every input/output/derived path under `process.cwd()` using
+ *     `path.relative` (sibling-prefix safe).
+ *   - Exposes `buildMagickPlan()` — a pure seam that returns the planned
+ *     (command, argv) without executing, so tests can pin the argv contract.
+ *
+ * Same `projectRoot` limitation as Row 10's TestRunnerTool — the tool is
+ * constructed without knowledge of the agent's project root, so it gates
+ * against `process.cwd()`. Tracked in Issue #17.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { Tool } from '../types';
 
-/** Check if ImageMagick is available */
-function hasMagick(): boolean {
-  try {
-    execSync('magick --version 2>/dev/null || convert --version 2>/dev/null', { stdio: 'pipe' });
-    return true;
-  } catch {
-    return false;
-  }
+// ─── Containment ────────────────────────────────────────────────────────────
+
+/**
+ * Decide whether `target` is contained within `root`.
+ * Uses path.relative, not startsWith — the latter trips on sibling prefixes
+ * like `/tmp/foo` vs `/tmp/foo-evil`.
+ */
+function isContained(root: string, target: string): boolean {
+  const absRoot = path.resolve(root);
+  const absTarget = path.resolve(target);
+  if (absRoot === absTarget) return true;
+  const rel = path.relative(absRoot, absTarget);
+  if (!rel) return true;
+  if (rel.startsWith('..')) return false;
+  if (path.isAbsolute(rel)) return false;
+  return true;
 }
 
-/** Get the ImageMagick command name */
-function magickCmd(): string {
-  try {
-    execSync('magick --version', { stdio: 'pipe' });
-    return 'magick';
-  } catch {
-    return 'convert';
+/**
+ * Resolve `p` against `root` and reject if the result escapes.
+ * Returns the absolute resolved path on success, or an error string.
+ */
+function resolveInside(root: string, p: string, label: string):
+  { resolved: string } | { error: string } {
+  const resolved = path.resolve(root, p);
+  if (!isContained(root, resolved)) {
+    return { error: `Error: ${label} escapes project root (${resolved} not under ${root})` };
   }
+  return { resolved };
 }
 
-/** Run an ImageMagick command, return stdout or error */
-function runMagick(args: string): string {
+// ─── Validators ─────────────────────────────────────────────────────────────
+
+/**
+ * Validate a value is a finite non-negative integer. TypeScript's `as number`
+ * cast is erased at runtime — the agent can still send a string. Guard here.
+ */
+function validateInt(v: unknown, name: string, min = 0, max = 100_000):
+  { n: number } | { error: string } {
+  const n = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < min || n > max) {
+    return { error: `Error: ${name} must be a finite integer in [${min}, ${max}]` };
+  }
+  return { n };
+}
+
+const ALLOWED_FORMATS = new Set(['png', 'jpg', 'jpeg', 'webp', 'gif', 'svg', 'ico']);
+
+function validateFormat(v: unknown):
+  { ok: string } | { error: string } {
+  if (typeof v !== 'string' || !ALLOWED_FORMATS.has(v.toLowerCase())) {
+    return { error: `Error: format must be one of ${[...ALLOWED_FORMATS].join(', ')}` };
+  }
+  return { ok: v.toLowerCase() };
+}
+
+/**
+ * Hex color validator. Accepts #RGB, #RRGGBB, #RRGGBBAA (3, 6, or 8 hex
+ * digits after the hash). Returns an error rather than a silent fallback
+ * because silent fallback can hide hostile input in an otherwise-valid SVG.
+ */
+function validateHexColor(v: unknown, name: string):
+  { ok: string } | { error: string } {
+  if (typeof v !== 'string' || !/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(v)) {
+    return { error: `Error: ${name} must be a hex color (#RGB, #RRGGBB, #RRGGBBAA)` };
+  }
+  return { ok: v };
+}
+
+// ─── ImageMagick probe (cached) ─────────────────────────────────────────────
+
+/**
+ * Probe once, cache forever. Expanding the probe into every action call
+ * would make the tool flaky and slow. A process-lifetime cache is fine
+ * because the binary state doesn't change mid-run.
+ */
+let _magickCache: { present: boolean; cmd: 'magick' | 'convert' | null } | null = null;
+
+function probeMagick(): { present: boolean; cmd: 'magick' | 'convert' | null } {
+  if (_magickCache !== null) return _magickCache;
   try {
-    return execSync(`${magickCmd()} ${args}`, {
+    execFileSync('magick', ['--version'], { stdio: 'pipe', timeout: 5_000 });
+    _magickCache = { present: true, cmd: 'magick' };
+    return _magickCache;
+  } catch { /* fall through */ }
+  try {
+    execFileSync('convert', ['--version'], { stdio: 'pipe', timeout: 5_000 });
+    _magickCache = { present: true, cmd: 'convert' };
+    return _magickCache;
+  } catch { /* fall through */ }
+  _magickCache = { present: false, cmd: null };
+  return _magickCache;
+}
+
+function hasMagick(): boolean { return probeMagick().present; }
+function magickCmd(): string { return probeMagick().cmd ?? 'magick'; }
+
+/** Reset the magick probe cache. Exposed for tests only. */
+export function __resetMagickCache(): void { _magickCache = null; }
+
+// ─── Exec helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Run magick/convert with an argv array. No shell. Metacharacters inside
+ * argv elements stay literal.
+ */
+function runMagickArgv(argv: string[]): string {
+  try {
+    return execFileSync(magickCmd(), argv, {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 30_000,
       maxBuffer: 10 * 1024 * 1024,
@@ -48,10 +155,10 @@ function runMagick(args: string): string {
   }
 }
 
-/** Run sips (macOS built-in) as fallback */
-function runSips(args: string): string {
+/** Run sips with an argv array. No shell. */
+function runSipsArgv(argv: string[]): string {
   try {
-    return execSync(`sips ${args}`, {
+    return execFileSync('sips', argv, {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 30_000,
     }).toString().trim();
@@ -65,6 +172,35 @@ function ensureDir(dir: string): void {
   fs.mkdirSync(dir, { recursive: true });
 }
 
+/** Compute a default output path from the input path, preserving extension. */
+function defaultOutput(input: string, suffix: string, ext?: string): string {
+  const inExt = path.extname(input);
+  const useExt = ext !== undefined ? ext : inExt;
+  return input.slice(0, input.length - inExt.length) + suffix + useExt;
+}
+
+/**
+ * Escape user text for embedding inside SVG text nodes. Attribute context
+ * has the same five replacements.
+ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+// ─── Plan type exported for tests ───────────────────────────────────────────
+
+export type MagickPlan =
+  | { backend: 'magick'; argv: string[] }
+  | { backend: 'sips'; argv: string[] }
+  | { error: string };
+
+// ───────────────────────────────────────────────────────────────────────────
+
 export class GraphicsTool implements Tool {
   name = 'graphics';
   description = 'Image processing, SVG generation & design assets. Actions: resize, convert, compress, crop, watermark, info, svg, favicon, og_image, combine. Uses ImageMagick/sips.';
@@ -76,11 +212,11 @@ export class GraphicsTool implements Tool {
         type: 'string',
         description: 'Action: resize, convert, compress, crop, watermark, info, svg, favicon, og_image, combine',
       },
-      input: { type: 'string', description: 'Input image path' },
-      output: { type: 'string', description: 'Output path (auto-generated if omitted)' },
+      input: { type: 'string', description: 'Input image path (must be inside project root)' },
+      output: { type: 'string', description: 'Output path (auto-generated if omitted; must be inside project root)' },
       width: { type: 'number', description: 'Target width in pixels' },
       height: { type: 'number', description: 'Target height in pixels' },
-      format: { type: 'string', description: 'Output format: png, jpg, webp, gif, svg, ico' },
+      format: { type: 'string', description: 'Output format: png, jpg, jpeg, webp, gif, svg, ico' },
       quality: { type: 'number', description: 'Compression quality 1-100 (for jpg/webp)' },
       // SVG specific
       svg_content: { type: 'string', description: 'SVG markup content (for svg action)' },
@@ -125,233 +261,451 @@ export class GraphicsTool implements Tool {
     }
   }
 
+  /**
+   * Pure seam for tests. Returns the planned (backend, argv) without
+   * executing. Lets tests pin the argv contract and catch regressions to
+   * string interpolation without stubbing child_process (whose exports are
+   * read-only getters in modern Node).
+   */
+  public buildMagickPlan(
+    action: string,
+    args: Record<string, unknown>,
+    cwd: string = process.cwd(),
+  ): MagickPlan {
+    switch (action) {
+      case 'resize': return this.planResize(args, cwd);
+      case 'convert': return this.planConvert(args, cwd);
+      case 'compress': return this.planCompress(args, cwd);
+      case 'crop': return this.planCrop(args, cwd);
+      case 'watermark': return this.planWatermark(args, cwd);
+      case 'info': return this.planInfo(args, cwd);
+      case 'combine': return this.planCombine(args, cwd);
+      case 'og_image': return this.planOgImagePng(args, cwd);
+      default: return { error: `Error: no plan for action "${action}"` };
+    }
+  }
+
+  // ─── resize ──────────────────────────────────────────────────────────────
+
+  private planResize(args: Record<string, unknown>, cwd: string): MagickPlan {
+    if (typeof args.input !== 'string' || args.input.length === 0) {
+      return { error: 'Error: input path is required' };
+    }
+    const inRes = resolveInside(cwd, args.input, 'input');
+    if ('error' in inRes) return inRes;
+
+    const hasW = args.width !== undefined && args.width !== null;
+    const hasH = args.height !== undefined && args.height !== null;
+    if (!hasW && !hasH) return { error: 'Error: width or height is required' };
+
+    let w: number | null = null;
+    let h: number | null = null;
+    if (hasW) {
+      const r = validateInt(args.width, 'width', 1);
+      if ('error' in r) return r;
+      w = r.n;
+    }
+    if (hasH) {
+      const r = validateInt(args.height, 'height', 1);
+      if ('error' in r) return r;
+      h = r.n;
+    }
+
+    const geometry = w !== null && h !== null ? `${w}x${h}!` : w !== null ? `${w}x` : `x${h}`;
+    const wLabel = w ?? '';
+    const hLabel = h ?? '';
+    const defOut = defaultOutput(inRes.resolved, `-${wLabel}x${hLabel}`);
+    const outPath = typeof args.output === 'string' && args.output.length > 0 ? args.output : defOut;
+    const outRes = resolveInside(cwd, outPath, 'output');
+    if ('error' in outRes) return outRes;
+
+    if (hasMagick()) {
+      return { backend: 'magick', argv: [inRes.resolved, '-resize', geometry, outRes.resolved] };
+    }
+    if (os.platform() === 'darwin') {
+      // sips modifies in place. The wrapper (runTests-style) copies first.
+      const sipsArgv = w !== null && h !== null
+        ? ['-z', String(h), String(w), outRes.resolved]
+        : w !== null
+          ? ['--resampleWidth', String(w), outRes.resolved]
+          : ['--resampleHeight', String(h), outRes.resolved];
+      return { backend: 'sips', argv: sipsArgv };
+    }
+    return { error: 'Error: ImageMagick not found. Install with: brew install imagemagick (macOS) or apt install imagemagick (Linux)' };
+  }
+
   private resize(args: Record<string, unknown>): string {
-    const input = args.input as string;
-    if (!input) return 'Error: input path is required';
-    if (!fs.existsSync(input)) return `Error: file not found: ${input}`;
-
-    const width = args.width as number;
-    const height = args.height as number;
-    if (!width && !height) return 'Error: width or height is required';
-
-    const ext = path.extname(input);
-    const output = (args.output as string) || input.replace(ext, `-${width || ''}x${height || ''}${ext}`);
-    const geometry = width && height ? `${width}x${height}!` : width ? `${width}x` : `x${height}`;
-
+    const plan = this.planResize(args, process.cwd());
+    if ('error' in plan) return plan.error;
     try {
-      if (hasMagick()) {
-        runMagick(`"${input}" -resize ${geometry} "${output}"`);
-      } else if (os.platform() === 'darwin') {
-        // macOS sips fallback
-        const sipsArgs = width && height
-          ? `-z ${height} ${width}`
-          : width ? `--resampleWidth ${width}` : `--resampleHeight ${height}`;
-        // sips modifies in-place, so copy first
-        fs.copyFileSync(input, output);
-        runSips(`${sipsArgs} "${output}"`);
-      } else {
-        return 'Error: ImageMagick not found. Install with: brew install imagemagick (macOS) or apt install imagemagick (Linux)';
+      if (plan.backend === 'sips') {
+        // Derive the resolved input/output from the plan's last arg.
+        const outPath = plan.argv[plan.argv.length - 1];
+        // Re-resolve input (it's not in the sips argv; pull from args).
+        const inputArg = args.input as string;
+        const inputResolved = path.resolve(process.cwd(), inputArg);
+        fs.copyFileSync(inputResolved, outPath);
+        runSipsArgv(plan.argv);
+        const stats = fs.statSync(outPath);
+        return `Resized → ${outPath} (${(stats.size / 1024).toFixed(1)}KB)`;
       }
-      const stats = fs.statSync(output);
-      return `Resized to ${geometry} → ${output} (${(stats.size / 1024).toFixed(1)}KB)`;
+      runMagickArgv(plan.argv);
+      const outPath = plan.argv[plan.argv.length - 1];
+      const stats = fs.statSync(outPath);
+      const geometry = plan.argv[plan.argv.indexOf('-resize') + 1];
+      return `Resized to ${geometry} → ${outPath} (${(stats.size / 1024).toFixed(1)}KB)`;
     } catch (err: unknown) {
       return `Error: ${err instanceof Error ? err.message : String(err)}`;
     }
+  }
+
+  // ─── convert ─────────────────────────────────────────────────────────────
+
+  private planConvert(args: Record<string, unknown>, cwd: string): MagickPlan {
+    if (typeof args.input !== 'string' || args.input.length === 0) {
+      return { error: 'Error: input path is required' };
+    }
+    const fmt = validateFormat(args.format);
+    if ('error' in fmt) return fmt;
+
+    const inRes = resolveInside(cwd, args.input, 'input');
+    if ('error' in inRes) return inRes;
+
+    const defOut = defaultOutput(inRes.resolved, '', `.${fmt.ok}`);
+    const outPath = typeof args.output === 'string' && args.output.length > 0 ? args.output : defOut;
+    const outRes = resolveInside(cwd, outPath, 'output');
+    if ('error' in outRes) return outRes;
+
+    let qualityArgs: string[] = [];
+    if (args.quality !== undefined && args.quality !== null) {
+      const q = validateInt(args.quality, 'quality', 1, 100);
+      if ('error' in q) return q;
+      qualityArgs = ['-quality', String(q.n)];
+    }
+
+    if (hasMagick()) {
+      return { backend: 'magick', argv: [inRes.resolved, ...qualityArgs, outRes.resolved] };
+    }
+    if (os.platform() === 'darwin') {
+      // sips maps jpg → jpeg.
+      const sipsFmt = fmt.ok === 'jpg' ? 'jpeg' : fmt.ok;
+      return { backend: 'sips', argv: ['-s', 'format', sipsFmt, outRes.resolved] };
+    }
+    return { error: 'Error: ImageMagick not found' };
   }
 
   private convert(args: Record<string, unknown>): string {
-    const input = args.input as string;
-    const format = args.format as string;
-    if (!input) return 'Error: input path is required';
-    if (!format) return 'Error: format is required (png, jpg, webp, gif)';
-    if (!fs.existsSync(input)) return `Error: file not found: ${input}`;
-
-    const ext = path.extname(input);
-    const output = (args.output as string) || input.replace(ext, `.${format}`);
-
+    const plan = this.planConvert(args, process.cwd());
+    if ('error' in plan) return plan.error;
     try {
-      if (hasMagick()) {
-        const quality = args.quality ? `-quality ${args.quality}` : '';
-        runMagick(`"${input}" ${quality} "${output}"`);
-      } else if (os.platform() === 'darwin') {
-        fs.copyFileSync(input, output);
-        runSips(`-s format ${format === 'jpg' ? 'jpeg' : format} "${output}"`);
-      } else {
-        return 'Error: ImageMagick not found';
+      if (plan.backend === 'sips') {
+        const outPath = plan.argv[plan.argv.length - 1];
+        const inputResolved = path.resolve(process.cwd(), args.input as string);
+        fs.copyFileSync(inputResolved, outPath);
+        runSipsArgv(plan.argv);
+        const stats = fs.statSync(outPath);
+        return `Converted → ${outPath} (${(stats.size / 1024).toFixed(1)}KB)`;
       }
-      const stats = fs.statSync(output);
-      return `Converted to ${format} → ${output} (${(stats.size / 1024).toFixed(1)}KB)`;
+      runMagickArgv(plan.argv);
+      const outPath = plan.argv[plan.argv.length - 1];
+      const stats = fs.statSync(outPath);
+      return `Converted → ${outPath} (${(stats.size / 1024).toFixed(1)}KB)`;
     } catch (err: unknown) {
       return `Error: ${err instanceof Error ? err.message : String(err)}`;
     }
+  }
+
+  // ─── compress ────────────────────────────────────────────────────────────
+
+  private planCompress(args: Record<string, unknown>, cwd: string): MagickPlan {
+    if (typeof args.input !== 'string' || args.input.length === 0) {
+      return { error: 'Error: input path is required' };
+    }
+    const inRes = resolveInside(cwd, args.input, 'input');
+    if ('error' in inRes) return inRes;
+
+    const q = validateInt(args.quality ?? 80, 'quality', 1, 100);
+    if ('error' in q) return q;
+
+    const defOut = defaultOutput(inRes.resolved, '-compressed');
+    const outPath = typeof args.output === 'string' && args.output.length > 0 ? args.output : defOut;
+    const outRes = resolveInside(cwd, outPath, 'output');
+    if ('error' in outRes) return outRes;
+
+    if (!hasMagick()) return { error: 'Error: ImageMagick not found (needed for compression)' };
+    return {
+      backend: 'magick',
+      argv: [inRes.resolved, '-strip', '-quality', String(q.n), outRes.resolved],
+    };
   }
 
   private compress(args: Record<string, unknown>): string {
-    const input = args.input as string;
-    if (!input) return 'Error: input path is required';
-    if (!fs.existsSync(input)) return `Error: file not found: ${input}`;
-
-    const quality = (args.quality as number) || 80;
-    const ext = path.extname(input);
-    const output = (args.output as string) || input.replace(ext, `-compressed${ext}`);
-    const beforeSize = fs.statSync(input).size;
-
+    const plan = this.planCompress(args, process.cwd());
+    if ('error' in plan) return plan.error;
     try {
-      if (hasMagick()) {
-        runMagick(`"${input}" -strip -quality ${quality} "${output}"`);
-      } else {
-        return 'Error: ImageMagick not found (needed for compression)';
-      }
-      const afterSize = fs.statSync(output).size;
+      const inputResolved = path.resolve(process.cwd(), args.input as string);
+      const beforeSize = fs.statSync(inputResolved).size;
+      runMagickArgv(plan.argv);
+      const outPath = plan.argv[plan.argv.length - 1];
+      const afterSize = fs.statSync(outPath).size;
+      const qIdx = plan.argv.indexOf('-quality');
+      const quality = qIdx >= 0 ? plan.argv[qIdx + 1] : '?';
       const savings = ((1 - afterSize / beforeSize) * 100).toFixed(1);
-      return `Compressed (quality ${quality}) → ${output}\n  ${(beforeSize / 1024).toFixed(1)}KB → ${(afterSize / 1024).toFixed(1)}KB (${savings}% smaller)`;
+      return `Compressed (quality ${quality}) → ${outPath}\n  ${(beforeSize / 1024).toFixed(1)}KB → ${(afterSize / 1024).toFixed(1)}KB (${savings}% smaller)`;
     } catch (err: unknown) {
       return `Error: ${err instanceof Error ? err.message : String(err)}`;
     }
+  }
+
+  // ─── crop ────────────────────────────────────────────────────────────────
+
+  private planCrop(args: Record<string, unknown>, cwd: string): MagickPlan {
+    if (typeof args.input !== 'string' || args.input.length === 0) {
+      return { error: 'Error: input path is required' };
+    }
+    const inRes = resolveInside(cwd, args.input, 'input');
+    if ('error' in inRes) return inRes;
+
+    const w = validateInt(args.width, 'width', 1);
+    if ('error' in w) return w;
+    const h = validateInt(args.height, 'height', 1);
+    if ('error' in h) return h;
+    const x = validateInt(args.x ?? 0, 'x', 0);
+    if ('error' in x) return x;
+    const y = validateInt(args.y ?? 0, 'y', 0);
+    if ('error' in y) return y;
+
+    const defOut = defaultOutput(inRes.resolved, '-cropped');
+    const outPath = typeof args.output === 'string' && args.output.length > 0 ? args.output : defOut;
+    const outRes = resolveInside(cwd, outPath, 'output');
+    if ('error' in outRes) return outRes;
+
+    if (hasMagick()) {
+      const geom = `${w.n}x${h.n}+${x.n}+${y.n}`;
+      return { backend: 'magick', argv: [inRes.resolved, '-crop', geom, '+repage', outRes.resolved] };
+    }
+    if (os.platform() === 'darwin') {
+      return {
+        backend: 'sips',
+        argv: ['-c', String(h.n), String(w.n), '--cropOffset', String(y.n), String(x.n), outRes.resolved],
+      };
+    }
+    return { error: 'Error: ImageMagick not found' };
   }
 
   private crop(args: Record<string, unknown>): string {
-    const input = args.input as string;
-    if (!input) return 'Error: input path is required';
-    if (!fs.existsSync(input)) return `Error: file not found: ${input}`;
-
-    const width = args.width as number;
-    const height = args.height as number;
-    if (!width || !height) return 'Error: width and height are required for crop';
-
-    const x = (args.x as number) || 0;
-    const y = (args.y as number) || 0;
-    const ext = path.extname(input);
-    const output = (args.output as string) || input.replace(ext, `-cropped${ext}`);
-
+    const plan = this.planCrop(args, process.cwd());
+    if ('error' in plan) return plan.error;
     try {
-      if (hasMagick()) {
-        runMagick(`"${input}" -crop ${width}x${height}+${x}+${y} +repage "${output}"`);
-      } else if (os.platform() === 'darwin') {
-        fs.copyFileSync(input, output);
-        runSips(`-c ${height} ${width} --cropOffset ${y} ${x} "${output}"`);
-      } else {
-        return 'Error: ImageMagick not found';
+      if (plan.backend === 'sips') {
+        const outPath = plan.argv[plan.argv.length - 1];
+        const inputResolved = path.resolve(process.cwd(), args.input as string);
+        fs.copyFileSync(inputResolved, outPath);
+        runSipsArgv(plan.argv);
+        return `Cropped → ${outPath}`;
       }
-      return `Cropped ${width}x${height}+${x}+${y} → ${output}`;
+      runMagickArgv(plan.argv);
+      const outPath = plan.argv[plan.argv.length - 1];
+      const geom = plan.argv[plan.argv.indexOf('-crop') + 1];
+      return `Cropped ${geom} → ${outPath}`;
     } catch (err: unknown) {
       return `Error: ${err instanceof Error ? err.message : String(err)}`;
     }
   }
 
-  private watermark(args: Record<string, unknown>): string {
-    const input = args.input as string;
-    const text = args.text as string;
-    if (!input || !text) return 'Error: input and text are required';
-    if (!fs.existsSync(input)) return `Error: file not found: ${input}`;
-    if (!hasMagick()) return 'Error: ImageMagick not found (needed for watermark)';
+  // ─── watermark ───────────────────────────────────────────────────────────
 
-    const position = (args.position as string) || 'bottom-right';
-    const ext = path.extname(input);
-    const output = (args.output as string) || input.replace(ext, `-watermarked${ext}`);
+  private planWatermark(args: Record<string, unknown>, cwd: string): MagickPlan {
+    if (typeof args.input !== 'string' || args.input.length === 0) {
+      return { error: 'Error: input is required' };
+    }
+    if (typeof args.text !== 'string' || args.text.length === 0) {
+      return { error: 'Error: text is required' };
+    }
+    if (!hasMagick()) return { error: 'Error: ImageMagick not found (needed for watermark)' };
 
+    const inRes = resolveInside(cwd, args.input, 'input');
+    if ('error' in inRes) return inRes;
+
+    const defOut = defaultOutput(inRes.resolved, '-watermarked');
+    const outPath = typeof args.output === 'string' && args.output.length > 0 ? args.output : defOut;
+    const outRes = resolveInside(cwd, outPath, 'output');
+    if ('error' in outRes) return outRes;
+
+    const position = typeof args.position === 'string' ? args.position : 'bottom-right';
     const gravityMap: Record<string, string> = {
       'center': 'Center', 'top-left': 'NorthWest', 'top-right': 'NorthEast',
       'bottom-left': 'SouthWest', 'bottom-right': 'SouthEast',
     };
-    const gravity = gravityMap[position] || 'SouthEast';
+    const gravity = gravityMap[position] ?? 'SouthEast';
 
+    // `text` is one argv element. Magick `-annotate` consumes it as the
+    // literal annotation string; shell metacharacters inside never reach
+    // any shell.
+    return {
+      backend: 'magick',
+      argv: [
+        inRes.resolved,
+        '-gravity', gravity,
+        '-fill', 'rgba(255,255,255,0.5)',
+        '-pointsize', '24',
+        '-annotate', '+10+10', args.text,
+        outRes.resolved,
+      ],
+    };
+  }
+
+  private watermark(args: Record<string, unknown>): string {
+    const plan = this.planWatermark(args, process.cwd());
+    if ('error' in plan) return plan.error;
     try {
-      runMagick(`"${input}" -gravity ${gravity} -fill "rgba(255,255,255,0.5)" -pointsize 24 -annotate +10+10 "${text}" "${output}"`);
-      return `Watermarked (${position}) → ${output}`;
+      runMagickArgv(plan.argv);
+      const outPath = plan.argv[plan.argv.length - 1];
+      const gravity = plan.argv[plan.argv.indexOf('-gravity') + 1];
+      return `Watermarked (${gravity}) → ${outPath}`;
     } catch (err: unknown) {
       return `Error: ${err instanceof Error ? err.message : String(err)}`;
     }
   }
 
-  private info(args: Record<string, unknown>): string {
-    const input = args.input as string;
-    if (!input) return 'Error: input path is required';
-    if (!fs.existsSync(input)) return `Error: file not found: ${input}`;
+  // ─── info ────────────────────────────────────────────────────────────────
 
-    const stats = fs.statSync(input);
-    const ext = path.extname(input).toLowerCase();
-    let details = `File: ${input}\n  Size: ${(stats.size / 1024).toFixed(1)}KB\n  Format: ${ext.slice(1)}`;
+  private planInfo(args: Record<string, unknown>, cwd: string): MagickPlan {
+    if (typeof args.input !== 'string' || args.input.length === 0) {
+      return { error: 'Error: input path is required' };
+    }
+    const inRes = resolveInside(cwd, args.input, 'input');
+    if ('error' in inRes) return inRes;
+
+    if (hasMagick()) {
+      return { backend: 'magick', argv: ['identify', '-verbose', inRes.resolved] };
+    }
+    if (os.platform() === 'darwin') {
+      return {
+        backend: 'sips',
+        argv: ['-g', 'pixelWidth', '-g', 'pixelHeight', '-g', 'format', inRes.resolved],
+      };
+    }
+    return { error: 'Error: no image introspection tool available (install ImageMagick)' };
+  }
+
+  private info(args: Record<string, unknown>): string {
+    // `info` wants filesystem metadata even if magick/sips aren't installed.
+    // We still validate & contain the path via the plan.
+    const plan = this.planInfo(args, process.cwd());
+    if ('error' in plan) return plan.error;
+    const inputResolved = plan.argv[plan.argv.length - 1];
+    if (!fs.existsSync(inputResolved)) return `Error: file not found: ${inputResolved}`;
+
+    const stats = fs.statSync(inputResolved);
+    const ext = path.extname(inputResolved).toLowerCase();
+    let details = `File: ${inputResolved}\n  Size: ${(stats.size / 1024).toFixed(1)}KB\n  Format: ${ext.slice(1)}`;
 
     try {
-      if (hasMagick()) {
-        const info = runMagick(`identify -verbose "${input}" 2>/dev/null | head -20`);
-        details += `\n  ${info}`;
-      } else if (os.platform() === 'darwin') {
-        const info = runSips(`-g pixelWidth -g pixelHeight -g format "${input}"`);
-        details += `\n  ${info}`;
+      let raw: string;
+      if (plan.backend === 'magick') {
+        raw = runMagickArgv(plan.argv);
+      } else {
+        raw = runSipsArgv(plan.argv);
       }
+      // Row 12 note: the old code piped through `| head -20` via a shell.
+      // Replaced with JS slicing — no shell dependency.
+      const truncated = raw.split('\n').slice(0, 20).join('\n');
+      details += `\n  ${truncated}`;
     } catch { /* info unavailable */ }
 
     return details;
   }
 
-  private svg(args: Record<string, unknown>): string {
-    const svgContent = args.svg_content as string;
-    const svgType = args.svg_type as string;
-    const output = args.output as string;
+  // ─── svg ─────────────────────────────────────────────────────────────────
 
-    if (svgContent) {
-      // Direct SVG content
-      if (!output) return 'Error: output path is required when providing svg_content';
-      ensureDir(path.dirname(output));
-      fs.writeFileSync(output, svgContent);
-      return `SVG saved to: ${output}`;
+  private svg(args: Record<string, unknown>): string {
+    const cwd = process.cwd();
+    const svgContent = args.svg_content;
+    const svgType = args.svg_type;
+    const outputArg = args.output;
+
+    if (typeof svgContent === 'string' && svgContent.length > 0) {
+      if (typeof outputArg !== 'string' || outputArg.length === 0) {
+        return 'Error: output path is required when providing svg_content';
+      }
+      const outRes = resolveInside(cwd, outputArg, 'output');
+      if ('error' in outRes) return outRes.error;
+      ensureDir(path.dirname(outRes.resolved));
+      fs.writeFileSync(outRes.resolved, svgContent);
+      return `SVG saved to: ${outRes.resolved}`;
     }
 
-    if (!svgType) return 'Error: svg_content or svg_type is required';
-    if (!output) return 'Error: output path is required';
+    if (typeof svgType !== 'string' || svgType.length === 0) {
+      return 'Error: svg_content or svg_type is required';
+    }
+    if (typeof outputArg !== 'string' || outputArg.length === 0) {
+      return 'Error: output path is required';
+    }
+    const outRes = resolveInside(cwd, outputArg, 'output');
+    if ('error' in outRes) return outRes.error;
 
-    const width = (args.width as number) || 64;
-    const height = (args.height as number) || 64;
-    const bgColor = (args.bg_color as string) || '#1a1a2e';
-    const accentColor = (args.accent_color as string) || '#6366f1';
-    const textColor = (args.text_color as string) || '#ffffff';
-    const text = (args.text as string) || '';
+    // Dimensions
+    const w = validateInt(args.width ?? 64, 'width', 1);
+    if ('error' in w) return w.error;
+    const h = validateInt(args.height ?? 64, 'height', 1);
+    if ('error' in h) return h.error;
+
+    // Colors — validated hex, never default-fallback-silently.
+    const bg = validateHexColor(args.bg_color ?? '#1a1a2e', 'bg_color');
+    if ('error' in bg) return bg.error;
+    const accent = validateHexColor(args.accent_color ?? '#6366f1', 'accent_color');
+    if ('error' in accent) return accent.error;
+    const text = validateHexColor(args.text_color ?? '#ffffff', 'text_color');
+    if ('error' in text) return text.error;
+
+    // Text content — XML-escape.
+    const label = typeof args.text === 'string' ? escapeXml(args.text) : '';
 
     let svg = '';
-
     switch (svgType) {
       case 'icon':
-        svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" fill="none">
-  <rect width="${width}" height="${height}" rx="${width * 0.15}" fill="${bgColor}"/>
-  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" fill="${textColor}" font-family="system-ui" font-size="${width * 0.4}" font-weight="bold">${text || '?'}</text>
+        svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w.n} ${h.n}" fill="none">
+  <rect width="${w.n}" height="${h.n}" rx="${(w.n * 0.15).toFixed(2)}" fill="${bg.ok}"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" fill="${text.ok}" font-family="system-ui" font-size="${(w.n * 0.4).toFixed(2)}" font-weight="bold">${label || '?'}</text>
 </svg>`;
         break;
 
-      case 'badge':
-        const badgeText = text || 'v1.0';
-        svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${Math.max(80, badgeText.length * 10 + 40)}" height="28" fill="none">
-  <rect width="100%" height="100%" rx="4" fill="${bgColor}"/>
-  <rect x="50%" width="50%" height="100%" rx="0" fill="${accentColor}"/>
-  <rect width="100%" height="100%" rx="4" fill="none" stroke="${accentColor}" stroke-width="0"/>
-  <text x="25%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="${textColor}" font-family="monospace" font-size="12">CodeBot</text>
-  <text x="75%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="${textColor}" font-family="monospace" font-size="12" font-weight="bold">${badgeText}</text>
+      case 'badge': {
+        const badgeText = label || 'v1.0';
+        const badgeW = Math.max(80, badgeText.length * 10 + 40);
+        svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${badgeW}" height="28" fill="none">
+  <rect width="100%" height="100%" rx="4" fill="${bg.ok}"/>
+  <rect x="50%" width="50%" height="100%" rx="0" fill="${accent.ok}"/>
+  <rect width="100%" height="100%" rx="4" fill="none" stroke="${accent.ok}" stroke-width="0"/>
+  <text x="25%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="${text.ok}" font-family="monospace" font-size="12">CodeBot</text>
+  <text x="75%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="${text.ok}" font-family="monospace" font-size="12" font-weight="bold">${badgeText}</text>
 </svg>`;
         break;
+      }
 
       case 'pattern':
-        svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" fill="none">
+        svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w.n} ${h.n}" fill="none">
   <defs>
     <pattern id="p" width="20" height="20" patternUnits="userSpaceOnUse">
-      <circle cx="10" cy="10" r="2" fill="${accentColor}" opacity="0.3"/>
+      <circle cx="10" cy="10" r="2" fill="${accent.ok}" opacity="0.3"/>
     </pattern>
   </defs>
-  <rect width="100%" height="100%" fill="${bgColor}"/>
+  <rect width="100%" height="100%" fill="${bg.ok}"/>
   <rect width="100%" height="100%" fill="url(#p)"/>
 </svg>`;
         break;
 
       case 'logo':
-        svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" fill="none">
+        svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w.n} ${h.n}" fill="none">
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop stop-color="${accentColor}"/>
-      <stop offset="1" stop-color="${bgColor}"/>
+      <stop stop-color="${accent.ok}"/>
+      <stop offset="1" stop-color="${bg.ok}"/>
     </linearGradient>
   </defs>
-  <circle cx="${width / 2}" cy="${height / 2}" r="${Math.min(width, height) * 0.4}" fill="url(#g)"/>
-  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" fill="${textColor}" font-family="system-ui" font-size="${width * 0.25}" font-weight="bold">${text || 'CB'}</text>
+  <circle cx="${(w.n / 2).toFixed(2)}" cy="${(h.n / 2).toFixed(2)}" r="${(Math.min(w.n, h.n) * 0.4).toFixed(2)}" fill="url(#g)"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" fill="${text.ok}" font-family="system-ui" font-size="${(w.n * 0.25).toFixed(2)}" font-weight="bold">${label || 'CB'}</text>
 </svg>`;
         break;
 
@@ -359,48 +713,69 @@ export class GraphicsTool implements Tool {
         return `Error: unknown svg_type "${svgType}". Available: icon, badge, pattern, logo`;
     }
 
-    ensureDir(path.dirname(output));
-    fs.writeFileSync(output, svg);
-    return `SVG (${svgType}) saved to: ${output}`;
+    ensureDir(path.dirname(outRes.resolved));
+    fs.writeFileSync(outRes.resolved, svg);
+    return `SVG (${svgType}) saved to: ${outRes.resolved}`;
   }
 
-  private favicon(args: Record<string, unknown>): string {
-    const input = args.input as string;
-    if (!input) return 'Error: input path (source image or SVG) is required';
-    if (!fs.existsSync(input)) return `Error: file not found: ${input}`;
+  // ─── favicon ─────────────────────────────────────────────────────────────
 
-    const outputDir = (args.output as string) || path.dirname(input);
-    const sizes = ((args.sizes as string) || '16,32,48,64,128,256').split(',').map(s => parseInt(s.trim()));
+  private favicon(args: Record<string, unknown>): string {
+    const cwd = process.cwd();
+    if (typeof args.input !== 'string' || args.input.length === 0) {
+      return 'Error: input path (source image or SVG) is required';
+    }
+    const inRes = resolveInside(cwd, args.input, 'input');
+    if ('error' in inRes) return inRes.error;
+    if (!fs.existsSync(inRes.resolved)) return `Error: file not found: ${inRes.resolved}`;
+
+    const outputDirArg = typeof args.output === 'string' && args.output.length > 0
+      ? args.output
+      : path.dirname(inRes.resolved);
+    const outDirRes = resolveInside(cwd, outputDirArg, 'output');
+    if ('error' in outDirRes) return outDirRes.error;
+    const outputDir = outDirRes.resolved;
+
+    const sizesStr = typeof args.sizes === 'string' ? args.sizes : '16,32,48,64,128,256';
+    const sizes: number[] = [];
+    for (const raw of sizesStr.split(',')) {
+      const v = validateInt(raw.trim(), 'sizes entry', 1, 2048);
+      if ('error' in v) return v.error;
+      sizes.push(v.n);
+    }
 
     ensureDir(outputDir);
+    const results: string[] = [];
 
-    // If input is SVG, just copy as favicon.svg
-    if (input.endsWith('.svg')) {
+    if (inRes.resolved.endsWith('.svg')) {
       const svgDest = path.join(outputDir, 'favicon.svg');
-      fs.copyFileSync(input, svgDest);
-      const results = [`  ${svgDest} (SVG)`];
+      fs.copyFileSync(inRes.resolved, svgDest);
+      results.push(`  ${svgDest} (SVG)`);
 
-      // Also generate PNG sizes if ImageMagick available
       if (hasMagick()) {
         for (const size of sizes) {
           const pngPath = path.join(outputDir, `favicon-${size}x${size}.png`);
           try {
-            runMagick(`-background none -density 300 "${input}" -resize ${size}x${size} "${pngPath}"`);
+            runMagickArgv([
+              '-background', 'none', '-density', '300',
+              inRes.resolved,
+              '-resize', `${size}x${size}`,
+              pngPath,
+            ]);
             results.push(`  ${pngPath} (${size}x${size})`);
           } catch { /* skip failed sizes */ }
         }
-
-        // Generate .ico (16 + 32 + 48)
-        const icoSources = [16, 32, 48].map(s => path.join(outputDir, `favicon-${s}x${s}.png`)).filter(f => fs.existsSync(f));
+        const icoSources = [16, 32, 48]
+          .map(s => path.join(outputDir, `favicon-${s}x${s}.png`))
+          .filter(f => fs.existsSync(f));
         if (icoSources.length) {
           const icoPath = path.join(outputDir, 'favicon.ico');
           try {
-            runMagick(`${icoSources.map(f => `"${f}"`).join(' ')} "${icoPath}"`);
+            runMagickArgv([...icoSources, icoPath]);
             results.push(`  ${icoPath} (ICO)`);
           } catch { /* ico generation failed */ }
         }
       }
-
       return `Favicon set generated:\n${results.join('\n')}`;
     }
 
@@ -409,27 +784,27 @@ export class GraphicsTool implements Tool {
       return 'Error: ImageMagick not found (needed to generate favicon set from raster image)';
     }
 
-    const results: string[] = [];
     for (const size of sizes) {
       const pngPath = path.join(outputDir, `favicon-${size}x${size}.png`);
       try {
         if (hasMagick()) {
-          runMagick(`"${input}" -resize ${size}x${size} "${pngPath}"`);
+          runMagickArgv([inRes.resolved, '-resize', `${size}x${size}`, pngPath]);
         } else {
-          fs.copyFileSync(input, pngPath);
-          runSips(`-z ${size} ${size} "${pngPath}"`);
+          fs.copyFileSync(inRes.resolved, pngPath);
+          runSipsArgv(['-z', String(size), String(size), pngPath]);
         }
         results.push(`  ${pngPath} (${size}x${size})`);
       } catch { /* skip failed sizes */ }
     }
 
-    // Generate .ico
     if (hasMagick()) {
-      const icoSources = [16, 32, 48].map(s => path.join(outputDir, `favicon-${s}x${s}.png`)).filter(f => fs.existsSync(f));
+      const icoSources = [16, 32, 48]
+        .map(s => path.join(outputDir, `favicon-${s}x${s}.png`))
+        .filter(f => fs.existsSync(f));
       if (icoSources.length) {
         const icoPath = path.join(outputDir, 'favicon.ico');
         try {
-          runMagick(`${icoSources.map(f => `"${f}"`).join(' ')} "${icoPath}"`);
+          runMagickArgv([...icoSources, icoPath]);
           results.push(`  ${icoPath} (ICO)`);
         } catch { /* ico failed */ }
       }
@@ -440,71 +815,141 @@ export class GraphicsTool implements Tool {
       : 'Error: failed to generate any favicon sizes';
   }
 
+  // ─── og_image ────────────────────────────────────────────────────────────
+
+  /**
+   * OG image PNG conversion plan. SVG assembly itself has no exec step —
+   * only the optional PNG rasterization does. Used by tests.
+   */
+  private planOgImagePng(args: Record<string, unknown>, cwd: string): MagickPlan {
+    const outputArg = typeof args.output === 'string' && args.output.length > 0
+      ? args.output
+      : path.join(cwd, 'og-image.svg');
+    const outRes = resolveInside(cwd, outputArg, 'output');
+    if ('error' in outRes) return outRes;
+    if (!outRes.resolved.endsWith('.svg')) {
+      return { error: 'Error: og_image PNG conversion requires .svg output path' };
+    }
+    if (!hasMagick()) return { error: 'Error: ImageMagick not found' };
+    const pngPath = outRes.resolved.replace(/\.svg$/, '.png');
+    return {
+      backend: 'magick',
+      argv: ['-background', 'none', '-density', '150', outRes.resolved, '-resize', '1200x630!', pngPath],
+    };
+  }
+
   private ogImage(args: Record<string, unknown>): string {
-    const title = (args.title as string) || 'Untitled';
-    const subtitle = (args.subtitle as string) || '';
-    const bgColor = (args.bg_color as string) || '#0f172a';
-    const textColor = (args.text_color as string) || '#f8fafc';
-    const accentColor = (args.accent_color as string) || '#6366f1';
-    const output = (args.output as string) || path.join(process.cwd(), 'og-image.svg');
+    const cwd = process.cwd();
+    const title = typeof args.title === 'string' ? args.title : 'Untitled';
+    const subtitle = typeof args.subtitle === 'string' ? args.subtitle : '';
+
+    const bg = validateHexColor(args.bg_color ?? '#0f172a', 'bg_color');
+    if ('error' in bg) return bg.error;
+    const text = validateHexColor(args.text_color ?? '#f8fafc', 'text_color');
+    if ('error' in text) return text.error;
+    const accent = validateHexColor(args.accent_color ?? '#6366f1', 'accent_color');
+    if ('error' in accent) return accent.error;
+
+    const outputArg = typeof args.output === 'string' && args.output.length > 0
+      ? args.output
+      : path.join(cwd, 'og-image.svg');
+    const outRes = resolveInside(cwd, outputArg, 'output');
+    if ('error' in outRes) return outRes.error;
 
     const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" fill="none">
-  <rect width="1200" height="630" fill="${bgColor}"/>
-  <rect x="0" y="610" width="1200" height="20" fill="${accentColor}"/>
-  <rect x="60" y="60" width="8" height="510" rx="4" fill="${accentColor}"/>
-  <text x="100" y="280" fill="${textColor}" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="bold">${escapeXml(title.substring(0, 50))}</text>
-  ${subtitle ? `<text x="100" y="350" fill="${textColor}" font-family="system-ui, -apple-system, sans-serif" font-size="28" opacity="0.7">${escapeXml(subtitle.substring(0, 80))}</text>` : ''}
-  <text x="100" y="520" fill="${accentColor}" font-family="monospace" font-size="20" opacity="0.8">CodeBot AI</text>
+  <rect width="1200" height="630" fill="${bg.ok}"/>
+  <rect x="0" y="610" width="1200" height="20" fill="${accent.ok}"/>
+  <rect x="60" y="60" width="8" height="510" rx="4" fill="${accent.ok}"/>
+  <text x="100" y="280" fill="${text.ok}" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="bold">${escapeXml(title.substring(0, 50))}</text>
+  ${subtitle ? `<text x="100" y="350" fill="${text.ok}" font-family="system-ui, -apple-system, sans-serif" font-size="28" opacity="0.7">${escapeXml(subtitle.substring(0, 80))}</text>` : ''}
+  <text x="100" y="520" fill="${accent.ok}" font-family="monospace" font-size="20" opacity="0.8">CodeBot AI</text>
 </svg>`;
 
-    ensureDir(path.dirname(output));
-    fs.writeFileSync(output, svg);
+    ensureDir(path.dirname(outRes.resolved));
+    fs.writeFileSync(outRes.resolved, svg);
 
-    // Also generate PNG version if ImageMagick available
     let pngNote = '';
-    if (hasMagick() && output.endsWith('.svg')) {
-      const pngPath = output.replace('.svg', '.png');
+    if (hasMagick() && outRes.resolved.endsWith('.svg')) {
+      const pngPath = outRes.resolved.replace(/\.svg$/, '.png');
       try {
-        runMagick(`-background none -density 150 "${output}" -resize 1200x630! "${pngPath}"`);
+        runMagickArgv([
+          '-background', 'none', '-density', '150',
+          outRes.resolved,
+          '-resize', '1200x630!',
+          pngPath,
+        ]);
         pngNote = `\n  PNG: ${pngPath}`;
       } catch { /* png conversion failed */ }
     }
 
-    return `OG image generated:\n  SVG: ${output}${pngNote}\n  Dimensions: 1200x630 (standard Open Graph)`;
+    return `OG image generated:\n  SVG: ${outRes.resolved}${pngNote}\n  Dimensions: 1200x630 (standard Open Graph)`;
+  }
+
+  // ─── combine ─────────────────────────────────────────────────────────────
+
+  private planCombine(args: Record<string, unknown>, cwd: string): MagickPlan {
+    if (typeof args.inputs !== 'string' || args.inputs.length === 0) {
+      return { error: 'Error: inputs is required (comma-separated file paths)' };
+    }
+    if (!hasMagick()) return { error: 'Error: ImageMagick not found (needed for combine)' };
+
+    const rawInputs = args.inputs.split(',').map(s => s.trim()).filter(Boolean);
+    if (rawInputs.length === 0) return { error: 'Error: inputs must contain at least one path' };
+
+    const resolved: string[] = [];
+    for (const f of rawInputs) {
+      const r = resolveInside(cwd, f, 'input');
+      if ('error' in r) return r;
+      resolved.push(r.resolved);
+    }
+
+    const direction = typeof args.direction === 'string' ? args.direction : 'horizontal';
+    if (!['horizontal', 'vertical', 'grid'].includes(direction)) {
+      return { error: `Error: unknown direction "${direction}". Use: horizontal, vertical, grid` };
+    }
+
+    const outputArg = typeof args.output === 'string' && args.output.length > 0
+      ? args.output
+      : path.join(cwd, `combined-${Date.now()}.png`);
+    const outRes = resolveInside(cwd, outputArg, 'output');
+    if ('error' in outRes) return outRes;
+
+    if (direction === 'horizontal') {
+      return { backend: 'magick', argv: [...resolved, '+append', outRes.resolved] };
+    }
+    if (direction === 'vertical') {
+      return { backend: 'magick', argv: [...resolved, '-append', outRes.resolved] };
+    }
+    // grid — use `montage` as the first argv element. Magick dispatches to
+    // the montage tool internally when invoked this way.
+    const cols = Math.ceil(Math.sqrt(resolved.length));
+    return {
+      backend: 'magick',
+      argv: ['montage', ...resolved, '-geometry', '+2+2', '-tile', `${cols}x`, outRes.resolved],
+    };
   }
 
   private combine(args: Record<string, unknown>): string {
-    const inputsStr = args.inputs as string;
-    if (!inputsStr) return 'Error: inputs is required (comma-separated file paths)';
-    if (!hasMagick()) return 'Error: ImageMagick not found (needed for combine)';
-
-    const inputs = inputsStr.split(',').map(s => s.trim()).filter(Boolean);
-    for (const f of inputs) {
-      if (!fs.existsSync(f)) return `Error: file not found: ${f}`;
-    }
-
-    const direction = (args.direction as string) || 'horizontal';
-    const output = (args.output as string) || path.join(process.cwd(), `combined-${Date.now()}.png`);
-
+    const plan = this.planCombine(args, process.cwd());
+    if ('error' in plan) return plan.error;
     try {
-      const quoted = inputs.map(f => `"${f}"`).join(' ');
-      if (direction === 'horizontal') {
-        runMagick(`${quoted} +append "${output}"`);
-      } else if (direction === 'vertical') {
-        runMagick(`${quoted} -append "${output}"`);
-      } else if (direction === 'grid') {
-        const cols = Math.ceil(Math.sqrt(inputs.length));
-        runMagick(`montage ${quoted} -geometry +2+2 -tile ${cols}x "${output}"`);
-      } else {
-        return `Error: unknown direction "${direction}". Use: horizontal, vertical, grid`;
+      // Verify each input file exists (containment already done in the plan).
+      for (const el of plan.argv) {
+        // Only check elements that look like paths (skip the magick flags).
+        if (el.startsWith('+') || el.startsWith('-') || el === 'montage') continue;
+        // Skip tile spec / the output (last).
+        if (/^\d+x$/.test(el)) continue;
       }
-      return `Combined ${inputs.length} images (${direction}) → ${output}`;
+      runMagickArgv(plan.argv);
+      const outPath = plan.argv[plan.argv.length - 1];
+      const direction = typeof args.direction === 'string' ? args.direction : 'horizontal';
+      // Count inputs: argv length minus known flag count.
+      const countGuess = plan.argv.filter(a =>
+        !a.startsWith('+') && !a.startsWith('-') && a !== 'montage' && !/^\d+x$/.test(a)
+      ).length - 1; // minus the output
+      return `Combined ${countGuess} images (${direction}) → ${outPath}`;
     } catch (err: unknown) {
       return `Error: ${err instanceof Error ? err.message : String(err)}`;
     }
   }
-}
-
-function escapeXml(str: string): string {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }


### PR DESCRIPTION
## Summary

- `GraphicsTool` assembled every ImageMagick / sips command by template-literal concatenation and handed it to `execSync` — same shell-injection class as Rows 9 / 10. **21 sinks** interpolated agent-supplied paths, text, format, and numeric dimensions raw. A call like `{action:'resize', input:'in.png', width:100, output:'x"; touch /tmp/pwned; echo "'}` broke out of the quote and executed the second branch.
- Switched every sink to `execFileSync(cmd, argv)`. No shell involved; metacharacters inside argv elements stay literal.
- Added runtime validators for numeric dimensions (strict `typeof v === 'number'`), format (whitelist), and hex colors. TS `as number` casts are erased — agent can still send strings.
- Contained every input/output/derived path under `process.cwd()` via `path.relative` (sibling-prefix safe).

## Design

- Extracted a pure `buildMagickPlan(action, args, cwd)` seam returning `{backend:'magick'|'sips', command:string, argv:string[]} | {error:string}`. Tests pin the argv contract without stubbing `child_process`.
- **Plans carry the actual executable.** `MagickPlan` includes `command`, so v7 (`magick <sub>`) and v6 (separate `convert`/`identify`/`montage` binaries) dispatch correctly. `magickSubcommand('identify'|'montage')` picks the right command + argv prefix per flavor. Pre-patch, v6 hosts silently invoked `convert identify -verbose <file>` — broken.
- `probeMagick()` probes once and caches `{flavor: 'v7' | 'v6' | null}` module-level. `__resetMagickCache()` and `__setMagickFlavorForTest()` exported for tests so v7/v6 branches are exercised without host binaries.
- **Strict numeric validation.** `validateInt()` requires `typeof v === 'number'` — `'100'`, `'1e3'`, `'0x10'` all rejected. Favicon `sizes` is intentionally a string field and uses `parseSizeToken()` with `/^\d+$/`.
- `info` no longer pipes through `| head -20` via a shell. Runs `identify -verbose` / `sips -g …` as argv, truncates output with `.split('\n').slice(0,20).join('\n')` in JS.
- SVG templates XML-escape `text` in every body (icon, badge, logo). Titles/subtitles were already escaped; extended coverage.
- Hex-color validator returns an error, not a silent fallback — silent fallback hides hostile input inside what looks like a valid SVG.
- `watermark.text` is one argv element. Magick `-annotate` consumes it as the literal annotation string.

## Review patches applied after initial commit

- **P2 — ImageMagick v6 flavor dispatch** (`3ab1c72`). Plans restructured to carry `command`. `planInfo` and `planCombine` grid use `magickSubcommand()` so v6 runs `identify`/`montage` as their own binaries, not as args to `convert`. Exported `__setMagickFlavorForTest()` so the test suite can force v7/v6 planning branches.
- **P3 — Strict numeric validation** (`3ab1c72`). `validateInt()` now requires `typeof v === 'number'`. Separate `parseSizeToken()` handles the favicon `sizes` string field with a digits-only regex.
- **CI fix** (`bf719ee`). Argv-shape suite forces `__setMagickFlavorForTest('v7')` in `before()` so assertions about planned argv work on CI hosts without ImageMagick installed.

## Out of scope (deliberate)

- Plumbing `projectRoot` into `GraphicsTool` — tracked in Issue #17 alongside TestRunnerTool. Current PR gates against `process.cwd()` using the Row 10 pattern.
- Policy / ToolRegistry / agent wiring — no changes.

## Test plan

- [x] `npm run build` — clean tsc
- [x] `node --test dist/tools/graphics.test.js` — **41/41 pass** across 7 describe blocks:
  - **Metadata** (3): name, permission, unknown-action error
  - **Argv-shape via `buildMagickPlan`** (14): resize / crop / convert / watermark / info / combine build discrete argv arrays with `command` set; malicious width/format strings rejected; string `'100'`, `'1e3'`, `100.5` rejected (P3); sibling-prefix output `workDir + '-evil'` rejected; `info` on `/etc/passwd` rejected (read-primitive closure); all allowed format values accepted; argv contains no `"` or shell pipes.
  - **Flavor-aware planning (P2)** (6): forces v7 → `command:'magick'`, argv starts `['identify',…]` / `['montage',…]`; forces v6 → `command:'identify'` / `command:'montage'` directly (the pre-patch v6 bug); resize command flips `magick` ↔ `convert`; combine horizontal under v6 uses `convert`.
  - **Favicon sizes parser (P3)** (2): rejects `'16,32,bad'` and `'16; ls'`.
  - **Color / text validation** (5): hostile `bg_color='"/><script>...'`, `accent_color='red'`, and `og_image` invalid color all return specific errors; no file written; SVG `text='</text><script>...'` gets `&lt;` / `&gt;` replacement in the written file; raw `<script>` never reaches disk; `svg_content` output outside cwd rejected.
  - **Canary real-exec** (4): marker files under `fs.mkdtempSync(os.tmpdir())`, drive `resize/output`, `watermark/text`, `combine/output`, `convert/format` with shell-injection payloads, assert the marker never appears. Works whether or not ImageMagick/sips is installed — ENOENT on the binary still never spawns a shell.
  - **Happy-path regression** (6): svg (icon, badge, logo, raw), og_image with `&`/`<>`/`'` escaping, info missing-file.
- [x] Verified locally on a host without ImageMagick (`which magick` → not found); all 41 tests still pass. This matches the CI environment.
- [x] `node --test dist/tools/tools.test.js` — 73/73 pass (no regression).
- [x] `node --test dist/tools/test-runner.test.js` — 12/12 pass (Row 10 unchanged).
- [x] `eslint src/tools/graphics.ts graphics.test.ts` — clean.
- [x] Scope: `src/tools/graphics.ts` + `src/tools/graphics.test.ts` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)