### PR TITLE
[FIX] Issue #11: Windows CI green — POSIX-normalize SymbolEntry.file + path.isAbsolute() in vault test

### DIFF
--- a/src/dashboard/vault-endpoint.test.ts
+++ b/src/dashboard/vault-endpoint.test.ts
@@ -206,7 +206,13 @@ describe('POST /api/command/vault — dashboard vault control', () => {
     );
     assert.strictEqual(res.status, 200);
     const body = JSON.parse(res.body);
-    assert.ok(body.vault.vaultPath.startsWith('/'), 'expanded path should be absolute');
+    // Issue #11: previously asserted .startsWith('/'), which is wrong on
+    // Windows where absolute paths look like `C:\Users\…`. The actual
+    // contract is "the path is absolute and the ~ token is gone".
+    assert.ok(
+      path.isAbsolute(body.vault.vaultPath),
+      `expanded path should be absolute, got ${body.vault.vaultPath}`,
+    );
     assert.ok(
       !body.vault.vaultPath.includes('~'),
       'expanded path should not contain ~',

--- a/src/symbol-indexer.test.ts
+++ b/src/symbol-indexer.test.ts
@@ -148,6 +148,25 @@ describe('SymbolIndexer', () => {
     assert.notStrictEqual(hits[0].file, hits[1].file);
   });
 
+  /**
+   * Issue #11 contract test. SymbolEntry.file is exposed to the agent,
+   * the dashboard, and the find-symbol tool — it MUST be POSIX-style
+   * regardless of host OS. On Windows pre-fix this would have been
+   * `deeply\nested\folder\thing.py` and downstream regex matchers and
+   * model-readable output broke. The boundary normalization in
+   * walkDir() makes the wire format platform-independent.
+   */
+  it('SymbolEntry.file is always POSIX-style (forward slashes), even on Windows', () => {
+    write('deeply/nested/folder/thing.py', 'class DeepThing: pass');
+    const idx = new SymbolIndexer(tmp);
+    const hits = idx.findByName('DeepThing');
+    assert.strictEqual(hits.length, 1);
+    assert.strictEqual(hits[0].file, 'deeply/nested/folder/thing.py',
+      'file must use forward slashes regardless of os.platform()');
+    assert.ok(!hits[0].file.includes('\\'),
+      `file must contain no backslashes; got ${hits[0].file}`);
+  });
+
   it('respects MAX_FILE_SIZE_BYTES (skips huge files)', () => {
     // 3 MB file should be skipped; 1 KB should be scanned
     const big = 'class Big: pass\n' + 'x'.repeat(3 * 1024 * 1024);

--- a/src/symbol-indexer.ts
+++ b/src/symbol-indexer.ts
@@ -36,9 +36,28 @@ export type SymbolKind =
 export interface SymbolEntry {
   name: string;
   kind: SymbolKind;
-  file: string;       // relative to projectRoot
+  /**
+   * Path relative to projectRoot, ALWAYS in POSIX form (forward slashes).
+   * Normalized at the boundary in `walkDir()` via `toPosixPath()` so that
+   * the same project produces the same `file` value on Windows, macOS,
+   * and Linux. Consumers (FindSymbolTool, dashboard, agent log lines)
+   * can rely on this without re-normalizing.
+   */
+  file: string;
   line: number;       // 1-based
   lang: 'python' | 'typescript' | 'javascript' | 'go' | 'rust' | 'ruby' | 'java';
+}
+
+/**
+ * Normalize a relative path to POSIX form. On POSIX hosts this is a
+ * no-op. On Windows, `path.relative` returns `mod\a.py`; we want
+ * `mod/a.py` so the wire format is platform-independent.
+ *
+ * Applied at the SymbolEntry boundary only — internal `path.join` /
+ * `fs.readdirSync` work in native form.
+ */
+function toPosixPath(p: string): string {
+  return path.sep === '/' ? p : p.split(path.sep).join('/');
 }
 
 /**
@@ -195,7 +214,9 @@ function walkDir(
     const ext = path.extname(entry.name);
     const spec = specForExt(ext);
     if (!spec) continue;
-    const rel = path.relative(root, abs);
+    // Normalize to POSIX-style at the boundary so SymbolEntry.file is
+    // platform-independent. See toPosixPath() docstring.
+    const rel = toPosixPath(path.relative(root, abs));
     scanFile(abs, rel, spec, out);
     counter.files++;
   }


### PR DESCRIPTION
Closes #11.

## Summary

Three Windows-only test failures have been red on every CI run since pre-PR-#10. Background-noise red is dangerous because real regressions hide behind it. This PR turns the matrix green so future security PRs can be trusted at a glance.

All three failures rooted in POSIX-only assumptions:

| # | Test | Failure | Fix |
|---|---|---|---|
| 1 | `POST expands ~ to homedir` | `startsWith('/')` is false on Windows (`C:\Users\…`) | Test: swap for `path.isAbsolute()`. Source already correct. |
| 2 | `SymbolIndexer — finds Python class …` | `expected: 'mod/a.py', actual: 'mod\\a.py'` | Source: normalize `path.relative(...)` to POSIX at the SymbolEntry boundary in `walkDir()`. |
| 3 | `FindSymbolTool — exact match returns declaration sites only` | regex `/django\/contrib\/admin\/.../ ` fails on `\` | Fixed transitively by #2 — `FindSymbolTool` prints `${h.file}:${h.line}` directly. |

## Design

Source-side normalization (vs test-side regex relaxing) because `SymbolEntry.file` is consumer-facing — it shows up in find-symbol output, dashboard displays, and agent log lines. Native separators in the wire format mean Windows and POSIX hosts produce different data for the same project. Models trained on POSIX paths see `mod\a.py` and may not match against `mod/a.py`. Git itself stores paths with `/` regardless of OS for the same reason.

A tiny local helper `toPosixPath()` lives next to `SymbolEntry` so the contract is documented at the boundary:

\`\`\`ts
function toPosixPath(p: string): string {
  return path.sep === '/' ? p : p.split(path.sep).join('/');
}
\`\`\`

No-op on POSIX, single split/join on Windows. Applied once where `SymbolEntry.file` is created. Internal `path.join` / `fs.readdirSync` keep native form.

`SymbolEntry.file` JSDoc updated to pin the contract: "ALWAYS in POSIX form."

## Out of scope (deliberate)

- **`ci.yml` / `actions/setup-python`** — Issue #11 speculated this might be needed. Repro showed the failing tests don't invoke a Python runtime; they write `.py` text and regex-index. No workflow change.
- **Issue #17 (projectRoot plumbing)** — separate sweep.
- **Other Windows / cross-platform paper cuts** — only fixing the three failures Issue #11 names.

## Test plan

- [x] `npm run build` — clean tsc
- [x] `node --test dist/symbol-indexer.test.js` — **11/11 pass** (was 10/10 + new contract test pinning POSIX-form `SymbolEntry.file`)
- [x] `node --test dist/tools/find-symbol.test.js` — 10/10 pass
- [x] `node --test dist/dashboard/vault-endpoint.test.js` — 7/7 pass
- [x] `node --test dist/tools/tools.test.js` — 73/73 (no regression)
- [x] `node --test dist/tools/graphics.test.js` — 41/41 (no regression)
- [x] `node --test dist/tools/test-runner.test.js` — 12/12 (no regression)
- [x] `npx eslint` on changed files — 0 errors
- [ ] Windows CI Node 18/20/22 — **acceptance criterion**

## Acceptance

Windows Node 18, 20, 22 → 0 failures. Linux/macOS unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)