### PR TITLE
[SECURITY] Issue #17: Plumb projectRoot into TestRunnerTool + GraphicsTool

### DIFF
--- a/src/tools/graphics.test.ts
+++ b/src/tools/graphics.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { GraphicsTool, __resetMagickCache, __setMagickFlavorForTest } from './graphics';
+import { GraphicsTool, __setMagickFlavorForTest } from './graphics';
 
 /**
  * GraphicsTool — injection, containment, validation, and flavor-aware
@@ -38,6 +38,97 @@ describe('GraphicsTool — metadata', () => {
   it('returns error for unknown action', async () => {
     const result = await tool.execute({ action: 'explode' });
     assert.ok(result.includes('Error: unknown action'));
+  });
+});
+
+/**
+ * Issue #17 — projectRoot is the policy boundary, not process.cwd().
+ *
+ * Pre-fix, every method gated against `process.cwd()`. A permission-
+ * approved graphics call could touch any path inside the launch dir,
+ * even ones outside the agent's declared project. Plumbing
+ * `Agent.projectRoot` through `ToolRegistry` into the tool closes
+ * that gap. Default `cwd` in `buildMagickPlan` now resolves to
+ * `this.projectRoot`, not `process.cwd()`.
+ */
+describe('GraphicsTool — Issue #17: projectRoot as policy boundary', () => {
+  let isolated: string;
+  let outerDir: string;
+  let outerFile: string;
+
+  before(() => {
+    // Two siblings under os.tmpdir(): one is the agent's projectRoot, the
+    // other is "outer" — outside projectRoot but a real, existing path.
+    // Creating both ourselves means the test doesn't depend on any repo
+    // file existing (per review tweak: containment is the point).
+    isolated = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-issue17-gfx-inner-'));
+    outerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-issue17-gfx-outer-'));
+    outerFile = path.join(outerDir, 'outside.png');
+    fs.writeFileSync(outerFile, 'x');
+    // Sanity-check: assertions below depend on the outer file actually
+    // existing on disk and being outside isolated.
+    assert.ok(fs.existsSync(outerFile), 'precondition: outer file must exist');
+    assert.ok(!outerFile.startsWith(isolated),
+      'precondition: outer file must be outside projectRoot');
+  });
+
+  after(() => {
+    try { fs.rmSync(isolated, { recursive: true, force: true }); } catch { /* ignore */ }
+    try { fs.rmSync(outerDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('input outside agent projectRoot is rejected (default cwd from constructor)', () => {
+    const tool = new GraphicsTool(isolated);
+    // No `cwd` override on buildMagickPlan — it must default to projectRoot,
+    // not process.cwd(). The outer file is a real, existing path; only
+    // containment can save us.
+    const plan = tool.buildMagickPlan('info', { input: outerFile });
+    assert.ok('error' in plan,
+      `expected containment rejection; got plan: ${JSON.stringify(plan)}`);
+    if ('error' in plan) {
+      assert.match(plan.error, /input escapes project root/);
+    }
+  });
+
+  it('input inside agent projectRoot is accepted (default cwd from constructor)', () => {
+    const inside = path.join(isolated, 'in.png');
+    fs.writeFileSync(inside, 'x');
+    const tool = new GraphicsTool(isolated);
+    // Force flavor so planning hits the magick branch even on no-IM hosts.
+    __setMagickFlavorForTest('v7');
+    try {
+      const plan = tool.buildMagickPlan('info', { input: inside });
+      assert.ok(!('error' in plan),
+        `expected plan; got error: ${'error' in plan ? plan.error : ''}`);
+    } finally {
+      __setMagickFlavorForTest(null);
+    }
+  });
+
+  it('back-compat: GraphicsTool() with no constructor arg still uses process.cwd() for containment', () => {
+    // The "no projectRoot supplied" case must keep behaving exactly as
+    // pre-Issue-17 — i.e. containment root is process.cwd(). We verify by
+    // creating a file inside a tmpdir under process.cwd(), then calling
+    // the tool with no constructor arg and asserting acceptance.
+    const innerInRepo = fs.mkdtempSync(path.join(process.cwd(), '.cb-issue17-bc-'));
+    const innerFile = path.join(innerInRepo, 'in.png');
+    fs.writeFileSync(innerFile, 'x');
+    try {
+      const tool = new GraphicsTool();  // no arg — back-compat path
+      __setMagickFlavorForTest('v7');
+      try {
+        const plan = tool.buildMagickPlan('info', { input: innerFile });
+        // Must NOT reject for containment, since innerFile is under process.cwd().
+        if ('error' in plan) {
+          assert.doesNotMatch(plan.error, /escapes project root/,
+            `back-compat path rejected an in-cwd file: ${plan.error}`);
+        }
+      } finally {
+        __setMagickFlavorForTest(null);
+      }
+    } finally {
+      try { fs.rmSync(innerInRepo, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
   });
 });
 

--- a/src/tools/graphics.ts
+++ b/src/tools/graphics.ts
@@ -26,14 +26,18 @@
  *     Favicon `sizes` is intentionally a string field and uses a separate
  *     digits-only parser.
  *   - Validates colors / format against whitelists.
- *   - Contains every input/output/derived path under `process.cwd()` using
- *     `path.relative` (sibling-prefix safe).
+ *   - Contains every input/output/derived path under the agent's project
+ *     root using `path.relative` (sibling-prefix safe).
  *   - Exposes `buildMagickPlan()` — a pure seam that returns the planned
  *     (command, argv) without executing, so tests can pin the argv contract.
  *
- * Same `projectRoot` limitation as Row 10's TestRunnerTool — the tool is
- * constructed without knowledge of the agent's project root, so it gates
- * against `process.cwd()`. Tracked in Issue #17.
+ * Issue #17 fix (2026-04-24): the containment root is now `this.projectRoot`,
+ * threaded from `Agent.projectRoot` via `ToolRegistry`. Pre-fix it was
+ * `process.cwd()` — strictly safer than nothing, but it conflated "where
+ * the process was launched" with "what directory tree the agent is allowed
+ * to touch." A permission-approved graphics call can no longer hop
+ * sideways out of the declared project. Constructor still falls back to
+ * `process.cwd()` for back-compat with ad-hoc instantiation (tests).
  */
 
 import * as fs from 'fs';
@@ -251,6 +255,16 @@ export class GraphicsTool implements Tool {
   name = 'graphics';
   description = 'Image processing, SVG generation & design assets. Actions: resize, convert, compress, crop, watermark, info, svg, favicon, og_image, combine. Uses ImageMagick/sips.';
   permission: Tool['permission'] = 'prompt';
+  /**
+   * Containment root. Issue #17: plumbed from `Agent.projectRoot` via
+   * `ToolRegistry`. Pre-fix every method gated against `process.cwd()`.
+   * Falls back to `process.cwd()` when constructed with no arg (tests,
+   * ad-hoc instantiation).
+   */
+  private readonly projectRoot: string;
+  constructor(projectRoot?: string) {
+    this.projectRoot = projectRoot || process.cwd();
+  }
   parameters = {
     type: 'object',
     properties: {
@@ -316,7 +330,7 @@ export class GraphicsTool implements Tool {
   public buildMagickPlan(
     action: string,
     args: Record<string, unknown>,
-    cwd: string = process.cwd(),
+    cwd: string = this.projectRoot,
   ): MagickPlan {
     switch (action) {
       case 'resize': return this.planResize(args, cwd);
@@ -384,12 +398,12 @@ export class GraphicsTool implements Tool {
   }
 
   private resize(args: Record<string, unknown>): string {
-    const plan = this.planResize(args, process.cwd());
+    const plan = this.planResize(args, this.projectRoot);
     if ('error' in plan) return plan.error;
     try {
       if (plan.backend === 'sips') {
         const outPath = plan.argv[plan.argv.length - 1];
-        const inputResolved = path.resolve(process.cwd(), args.input as string);
+        const inputResolved = path.resolve(this.projectRoot, args.input as string);
         fs.copyFileSync(inputResolved, outPath);
         runPlan(plan.command, plan.argv, 'sips');
         const stats = fs.statSync(outPath);
@@ -448,12 +462,12 @@ export class GraphicsTool implements Tool {
   }
 
   private convert(args: Record<string, unknown>): string {
-    const plan = this.planConvert(args, process.cwd());
+    const plan = this.planConvert(args, this.projectRoot);
     if ('error' in plan) return plan.error;
     try {
       if (plan.backend === 'sips') {
         const outPath = plan.argv[plan.argv.length - 1];
-        const inputResolved = path.resolve(process.cwd(), args.input as string);
+        const inputResolved = path.resolve(this.projectRoot, args.input as string);
         fs.copyFileSync(inputResolved, outPath);
         runPlan(plan.command, plan.argv, 'sips');
         const stats = fs.statSync(outPath);
@@ -494,10 +508,10 @@ export class GraphicsTool implements Tool {
   }
 
   private compress(args: Record<string, unknown>): string {
-    const plan = this.planCompress(args, process.cwd());
+    const plan = this.planCompress(args, this.projectRoot);
     if ('error' in plan) return plan.error;
     try {
-      const inputResolved = path.resolve(process.cwd(), args.input as string);
+      const inputResolved = path.resolve(this.projectRoot, args.input as string);
       const beforeSize = fs.statSync(inputResolved).size;
       runPlan(plan.command, plan.argv, 'magick');
       const outPath = plan.argv[plan.argv.length - 1];
@@ -553,12 +567,12 @@ export class GraphicsTool implements Tool {
   }
 
   private crop(args: Record<string, unknown>): string {
-    const plan = this.planCrop(args, process.cwd());
+    const plan = this.planCrop(args, this.projectRoot);
     if ('error' in plan) return plan.error;
     try {
       if (plan.backend === 'sips') {
         const outPath = plan.argv[plan.argv.length - 1];
-        const inputResolved = path.resolve(process.cwd(), args.input as string);
+        const inputResolved = path.resolve(this.projectRoot, args.input as string);
         fs.copyFileSync(inputResolved, outPath);
         runPlan(plan.command, plan.argv, 'sips');
         return `Cropped → ${outPath}`;
@@ -613,7 +627,7 @@ export class GraphicsTool implements Tool {
   }
 
   private watermark(args: Record<string, unknown>): string {
-    const plan = this.planWatermark(args, process.cwd());
+    const plan = this.planWatermark(args, this.projectRoot);
     if ('error' in plan) return plan.error;
     try {
       runPlan(plan.command, plan.argv, 'magick');
@@ -656,7 +670,7 @@ export class GraphicsTool implements Tool {
   }
 
   private info(args: Record<string, unknown>): string {
-    const plan = this.planInfo(args, process.cwd());
+    const plan = this.planInfo(args, this.projectRoot);
     if ('error' in plan) return plan.error;
     const inputResolved = plan.argv[plan.argv.length - 1];
     if (!fs.existsSync(inputResolved)) return `Error: file not found: ${inputResolved}`;
@@ -679,7 +693,7 @@ export class GraphicsTool implements Tool {
   // ─── svg ─────────────────────────────────────────────────────────────────
 
   private svg(args: Record<string, unknown>): string {
-    const cwd = process.cwd();
+    const cwd = this.projectRoot;
     const svgContent = args.svg_content;
     const svgType = args.svg_type;
     const outputArg = args.output;
@@ -780,7 +794,7 @@ export class GraphicsTool implements Tool {
   // ─── favicon ─────────────────────────────────────────────────────────────
 
   private favicon(args: Record<string, unknown>): string {
-    const cwd = process.cwd();
+    const cwd = this.projectRoot;
     if (typeof args.input !== 'string' || args.input.length === 0) {
       return 'Error: input path (source image or SVG) is required';
     }
@@ -902,7 +916,7 @@ export class GraphicsTool implements Tool {
   }
 
   private ogImage(args: Record<string, unknown>): string {
-    const cwd = process.cwd();
+    const cwd = this.projectRoot;
     const title = typeof args.title === 'string' ? args.title : 'Untitled';
     const subtitle = typeof args.subtitle === 'string' ? args.subtitle : '';
 
@@ -1002,7 +1016,7 @@ export class GraphicsTool implements Tool {
   }
 
   private combine(args: Record<string, unknown>): string {
-    const plan = this.planCombine(args, process.cwd());
+    const plan = this.planCombine(args, this.projectRoot);
     if ('error' in plan) return plan.error;
     try {
       runPlan(plan.command, plan.argv, 'magick');

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -164,7 +164,7 @@ export class ToolRegistry {
     regIf(new DiffViewerTool());
     regIf(new DockerTool());
     regIf(new DatabaseTool());
-    regIf(new TestRunnerTool());
+    regIf(new TestRunnerTool(projectRoot));
     regIf(new HttpClientTool());
     regIf(new ImageInfoTool());
     regIf(new SshRemoteTool());
@@ -206,7 +206,7 @@ export class ToolRegistry {
     }
 
     // Non-connector tools — always register regardless of connector status
-    regIf(new GraphicsTool());
+    regIf(new GraphicsTool(projectRoot));
     regIf(new DeepResearchTool());
     regIf(new SkillForgeTool());
     regIf(new DecomposeGoalTool());

--- a/src/tools/test-runner.test.ts
+++ b/src/tools/test-runner.test.ts
@@ -61,6 +61,51 @@ describe('TestRunnerTool — cwd containment', () => {
 });
 
 /**
+ * Issue #17 — projectRoot is the policy boundary, not process.cwd().
+ *
+ * Pre-fix, `TestRunnerTool` baked `process.cwd()` into containment via
+ * Row 10. If CodeBot was launched from a directory broader than the
+ * agent's actual project (home dir, monorepo parent), a permission-
+ * approved `test_runner` call could hop sideways within that broader
+ * directory. Plumbing `Agent.projectRoot` through `ToolRegistry` into
+ * the tool closes that gap.
+ */
+describe('TestRunnerTool — Issue #17: projectRoot as policy boundary', () => {
+  it('rejects cwd outside the agent projectRoot, even when inside process.cwd()', async () => {
+    // Put projectRoot at a tmpdir that does NOT contain the test repo.
+    // process.cwd() is the test repo itself — broader than projectRoot.
+    // A cwd of process.cwd() must be rejected.
+    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-issue17-tr-'));
+    try {
+      const tool = new TestRunnerTool(isolated);
+      const result = await tool.execute({ action: 'detect', cwd: process.cwd() });
+      assert.ok(
+        result.startsWith('Error: cwd escapes project root'),
+        `expected rejection (projectRoot=${isolated}, cwd=${process.cwd()}), got: ${result}`,
+      );
+    } finally {
+      try { fs.rmSync(isolated, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it('accepts cwd inside the agent projectRoot, even when projectRoot != process.cwd()', async () => {
+    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-issue17-tr-'));
+    const sub = path.join(isolated, 'sub');
+    fs.mkdirSync(sub);
+    try {
+      const tool = new TestRunnerTool(isolated);
+      const result = await tool.execute({ action: 'detect', cwd: sub });
+      assert.ok(
+        !result.startsWith('Error: cwd escapes project root'),
+        `expected accept (projectRoot=${isolated}, cwd=${sub}), got: ${result}`,
+      );
+    } finally {
+      try { fs.rmSync(isolated, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+});
+
+/**
  * Real integration test. We build a tiny fake jest project in an
  * isolated tmpdir, drive the tool with a filter that would spawn a
  * subprocess if — and only if — the shell interpreted it. Then we

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -38,13 +38,25 @@ export class TestRunnerTool implements Tool {
   name = 'test_runner';
   description = 'Run tests with auto-detected framework. Actions: run (execute tests), detect (show detected framework), list (list test files).';
   permission: Tool['permission'] = 'prompt';
+  /**
+   * Containment root. Issue #17: was `process.cwd()` baked in via Row 10;
+   * now plumbed from `Agent.projectRoot` via `ToolRegistry` so a permission-
+   * approved test_runner call can never hop sideways out of the agent's
+   * declared project, regardless of where the process happens to be CWD'd.
+   * Falls back to `process.cwd()` for back-compat with callers that still
+   * `new TestRunnerTool()` with no arg (tests, ad-hoc instantiation).
+   */
+  private readonly projectRoot: string;
+  constructor(projectRoot?: string) {
+    this.projectRoot = projectRoot || process.cwd();
+  }
   parameters = {
     type: 'object',
     properties: {
       action: { type: 'string', description: 'Action: run, detect, list' },
       path: { type: 'string', description: 'Test file or directory (defaults to project root)' },
       filter: { type: 'string', description: 'Test name filter / grep pattern' },
-      cwd: { type: 'string', description: 'Working directory (must be inside the process cwd)' },
+      cwd: { type: 'string', description: 'Working directory (must be inside the project root)' },
     },
     required: ['action'],
   };
@@ -54,18 +66,18 @@ export class TestRunnerTool implements Tool {
     if (!action) return 'Error: action is required';
 
     // cwd containment. If the caller passes a cwd, it must be within the
-    // process cwd. We never clamp silently — we reject. This matches the
-    // streaming exec gate's behavior.
-    const processRoot = process.cwd();
+    // agent's declared project root (Issue #17). We never clamp silently —
+    // we reject. This matches the streaming exec gate's behavior.
+    const root = this.projectRoot;
     let cwd: string;
     if (typeof args.cwd === 'string' && args.cwd.length > 0) {
-      const resolved = path.resolve(processRoot, args.cwd);
-      if (!isContained(processRoot, resolved)) {
-        return `Error: cwd escapes project root (${resolved} not under ${processRoot})`;
+      const resolved = path.resolve(root, args.cwd);
+      if (!isContained(root, resolved)) {
+        return `Error: cwd escapes project root (${resolved} not under ${root})`;
       }
       cwd = resolved;
     } else {
-      cwd = processRoot;
+      cwd = root;
     }
 
     switch (action) {


### PR DESCRIPTION
Closes #17.

## Summary

Rows 10 and 12 closed shell-injection in TestRunnerTool and GraphicsTool, but both gated containment against `process.cwd()` baked in at the call site. Issue #17 documented the gap: if CodeBot is ever launched from a directory broader than the agent's actual project (home dir, monorepo parent), a permission-approved call can hop sideways within that broader tree.

This PR plumbs `Agent.projectRoot` through `ToolRegistry` into both tools, matching the established pattern used by 9 other tools (ReadFileTool, WriteFileTool, EditFileTool, BatchEditTool, ExecuteTool, GlobTool, GrepTool, FindSymbolTool, MemoryTool):

\`\`\`ts
constructor(projectRoot?: string) {
  this.projectRoot = projectRoot || process.cwd();
}
\`\`\`

Each method's containment now uses `this.projectRoot`. Optional arg preserves back-compat: `new TestRunnerTool()` / `new GraphicsTool()` with no arg still falls through to `process.cwd()`, so ad-hoc instantiation paths (tests, scripts) keep working unchanged.

## Diff

| File | Change |
|---|---|
| `src/tools/test-runner.ts` | +constructor, replace `processRoot` with `this.projectRoot`; `cwd` schema description updated |
| `src/tools/graphics.ts` | +constructor, replace 13 `process.cwd()` sites with `this.projectRoot` (incl. `buildMagickPlan` default param); header docstring updated, Issue #17 caveat removed |
| `src/tools/index.ts` | Pass `projectRoot` to `TestRunnerTool` and `GraphicsTool` (already in scope, just dropped at construction) |
| `src/tools/test-runner.test.ts` | +2 tests pinning the projectRoot-vs-`process.cwd()` distinction |
| `src/tools/graphics.test.ts` | +3 tests pinning containment via the default-cwd path + back-compat assertion |

## Tests added

**TestRunnerTool**:
- `rejects cwd outside the agent projectRoot, even when inside process.cwd()` — the actual Issue #17 acceptance criterion
- `accepts cwd inside the agent projectRoot, even when projectRoot != process.cwd()` — the inverse

**GraphicsTool**:
- `input outside agent projectRoot is rejected (default cwd from constructor)` — proves `buildMagickPlan` default uses `this.projectRoot`
- `input inside agent projectRoot is accepted (default cwd from constructor)` — inverse
- `back-compat: GraphicsTool() with no constructor arg still uses process.cwd() for containment` — pins the optional-arg back-compat contract

Per review tweak: outer file is created in `os.tmpdir()` with an explicit `fs.existsSync` precondition. Tests do not depend on any repo file existing.

## Out of scope (deliberate)

- **DockerTool** (`docker.ts:31`), **PackageManagerTool** (`package-manager.ts:91`) — both accept `cwd` with NO containment whatsoever, strictly worse than pre-Row-10 TestRunnerTool. These are Row 8/9-class findings (consume via `execSync(string)`, same shell-injection class) and will be addressed in those rows, not folded into Issue #17.
- **Tool interface change** — none. Each tool keeps a private `projectRoot` field. The Tool interface stays minimal.

## Verification

- [x] `npm run build` — clean tsc
- [x] `node --test dist/tools/test-runner.test.js` — **14/14 pass** (was 12, +2 new)
- [x] `node --test dist/tools/graphics.test.js` — **44/44 pass** (was 41, +3 new)
- [x] `node --test dist/tools/tools.test.js` — 73/73 (no regression)
- [x] `node --test dist/symbol-indexer.test.js` + `vault-endpoint` + `find-symbol` — 28/28 (Issue #11 unchanged)
- [x] `npx eslint` on changed files — 0 errors, 0 warnings
- [ ] CI matrix Linux/macOS/Windows × Node 18/20/22 — should stay all-green per Issue #11 closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)