### PR TITLE
[SECURITY] Row 8 (PR-A): Close local-shell injection in SshRemoteTool + DatabaseTool

### DIFF
--- a/src/tools/database.test.ts
+++ b/src/tools/database.test.ts
@@ -1,12 +1,25 @@
 import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert';
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { DatabaseTool } from './database';
 
 /**
  * DatabaseTool tests — validates SQL blocking patterns, input validation,
- * action routing, and error messages. Tests do NOT require sqlite3 or
- * a real database; they test the validation and routing logic only.
+ * action routing, error messages, and (Row 8) argv-based exec + db-path
+ * containment under projectRoot.
+ *
+ * Tests do NOT require sqlite3 or a real database; they test validation,
+ * routing, argv shape, and containment.
+ *
+ * Row 8 fix (2026-04-24): pre-fix, every action used
+ *   `execSync(\`sqlite3 "${dbPath}" "${command.replace(/"/g, '\\"')}"\`)`
+ * Both `dbPath` and `sql` were placed inside double quotes — and bash
+ * expands `$(...)`, backticks, and `${...}` INSIDE double quotes. The
+ * `replace(/"/g, '\\"')` only escaped `"`, not the substitution
+ * metacharacters. So `sql = 'SELECT 1; \`touch /tmp/pwned\`'` would
+ * spawn `touch` LOCALLY before sqlite3 ever ran.
  */
 
 describe('DatabaseTool — metadata', () => {
@@ -28,19 +41,23 @@ describe('DatabaseTool — metadata', () => {
 });
 
 describe('DatabaseTool — input validation', () => {
-  const tool = new DatabaseTool();
-  const tempDbForValidation = '/tmp/codebot-test-validation.db';
+  let workDir: string;
+  let tempDb: string;
+  let tool: DatabaseTool;
 
   before(() => {
-    fs.writeFileSync(tempDbForValidation, '', 'utf-8');
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-db-validation-'));
+    tempDb = path.join(workDir, 'validation.db');
+    fs.writeFileSync(tempDb, '', 'utf-8');
+    tool = new DatabaseTool(workDir);
   });
 
   after(() => {
-    try { fs.unlinkSync(tempDbForValidation); } catch { /* ignore */ }
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
   it('returns error when action is missing', async () => {
-    const result = await tool.execute({ db: tempDbForValidation });
+    const result = await tool.execute({ db: tempDb });
     assert.ok(result.includes('Error: action is required'));
   });
 
@@ -49,13 +66,14 @@ describe('DatabaseTool — input validation', () => {
     assert.ok(result.includes('Error: db path is required'));
   });
 
-  it('returns error for nonexistent database file', async () => {
-    const result = await tool.execute({ action: 'query', db: '/tmp/nonexistent-db-file-codebot-test.db' });
+  it('returns error for nonexistent database file (inside projectRoot)', async () => {
+    const missing = path.join(workDir, 'nonexistent.db');
+    const result = await tool.execute({ action: 'query', db: missing, sql: 'SELECT 1' });
     assert.ok(result.includes('Error: database not found'));
   });
 
   it('returns error for unknown action', async () => {
-    const result = await tool.execute({ action: 'destroy', db: tempDbForValidation });
+    const result = await tool.execute({ action: 'destroy', db: tempDb });
     assert.ok(result.includes('Error: unknown action'));
     assert.ok(result.includes('destroy'));
     assert.ok(result.includes('query, tables, schema, info'));
@@ -63,27 +81,24 @@ describe('DatabaseTool — input validation', () => {
 });
 
 describe('DatabaseTool — SQL blocking (destructive queries)', () => {
-  const tool = new DatabaseTool();
+  let workDir: string;
+  let tempDbPath: string;
+  let tool: DatabaseTool;
 
-  // For these tests, the db file must "exist" to get past the fs check,
-  // but we only need to test the SQL blocking logic which runs before sqlite3 exec.
-  // We create a minimal temp file.
-  const tempDbPath = '/tmp/codebot-test-blocking.db';
-
-  // Create a minimal file so fs.existsSync passes
   before(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-db-blocking-'));
+    tempDbPath = path.join(workDir, 'blocking.db');
     fs.writeFileSync(tempDbPath, '', 'utf-8');
+    tool = new DatabaseTool(workDir);
   });
 
   after(() => {
-    try { fs.unlinkSync(tempDbPath); } catch { /* ignore */ }
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
   it('blocks DROP TABLE statements', async () => {
     const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
-      sql: 'DROP TABLE users;',
+      action: 'query', db: tempDbPath, sql: 'DROP TABLE users;',
     });
     assert.ok(result.includes('Error: destructive SQL blocked'));
     assert.ok(result.includes('DROP'));
@@ -91,18 +106,14 @@ describe('DatabaseTool — SQL blocking (destructive queries)', () => {
 
   it('blocks DROP DATABASE statements', async () => {
     const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
-      sql: 'DROP DATABASE production;',
+      action: 'query', db: tempDbPath, sql: 'DROP DATABASE production;',
     });
     assert.ok(result.includes('Error: destructive SQL blocked'));
   });
 
   it('blocks DELETE FROM statements', async () => {
     const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
-      sql: 'DELETE FROM users WHERE id > 0;',
+      action: 'query', db: tempDbPath, sql: 'DELETE FROM users WHERE id > 0;',
     });
     assert.ok(result.includes('Error: destructive SQL blocked'));
     assert.ok(result.includes('DELETE'));
@@ -110,9 +121,7 @@ describe('DatabaseTool — SQL blocking (destructive queries)', () => {
 
   it('blocks TRUNCATE statements', async () => {
     const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
-      sql: 'TRUNCATE TABLE sessions;',
+      action: 'query', db: tempDbPath, sql: 'TRUNCATE TABLE sessions;',
     });
     assert.ok(result.includes('Error: destructive SQL blocked'));
     assert.ok(result.includes('TRUNCATE'));
@@ -120,69 +129,207 @@ describe('DatabaseTool — SQL blocking (destructive queries)', () => {
 
   it('blocks ALTER TABLE ... DROP statements', async () => {
     const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
-      sql: 'ALTER TABLE users DROP COLUMN email;',
+      action: 'query', db: tempDbPath, sql: 'ALTER TABLE users DROP COLUMN email;',
     });
     assert.ok(result.includes('Error: destructive SQL blocked'));
   });
 
   it('blocks case-insensitive variations of destructive SQL', async () => {
     const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
-      sql: 'drop table users;',
+      action: 'query', db: tempDbPath, sql: 'drop table users;',
     });
     assert.ok(result.includes('Error: destructive SQL blocked'));
   });
 
   it('blocks mixed case destructive SQL', async () => {
     const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
-      sql: 'Delete From users WHERE 1=1;',
+      action: 'query', db: tempDbPath, sql: 'Delete From users WHERE 1=1;',
     });
     assert.ok(result.includes('Error: destructive SQL blocked'));
   });
 
   it('does not block SELECT statements (safe query passes validation)', async () => {
-    // This will get past the blocking check but will likely fail on
-    // sqlite3 execution (file is not a real db). The key assertion is
-    // that the error is NOT about "destructive SQL blocked".
     const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
-      sql: 'SELECT * FROM users;',
+      action: 'query', db: tempDbPath, sql: 'SELECT * FROM users;',
     });
     assert.ok(!result.includes('destructive SQL blocked'));
   });
 
   it('does not block SELECT with subqueries', async () => {
     const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
+      action: 'query', db: tempDbPath,
       sql: 'SELECT count(*) FROM (SELECT id FROM users WHERE active=1);',
     });
     assert.ok(!result.includes('destructive SQL blocked'));
   });
 
   it('returns error when sql is missing for query action', async () => {
-    const result = await tool.execute({
-      action: 'query',
-      db: tempDbPath,
-    });
+    const result = await tool.execute({ action: 'query', db: tempDbPath });
     assert.ok(result.includes('Error: sql is required for query'));
   });
 });
 
 describe('DatabaseTool — tables action on nonexistent db', () => {
-  const tool = new DatabaseTool();
+  it('returns error for tables action on missing db (inside projectRoot)', async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-db-tables-'));
+    try {
+      const tool = new DatabaseTool(workDir);
+      const missing = path.join(workDir, 'no-such-db.db');
+      const result = await tool.execute({ action: 'tables', db: missing });
+      assert.ok(result.includes('Error: database not found'));
+    } finally {
+      try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+});
 
-  it('returns error for tables action on missing db', async () => {
-    const result = await tool.execute({
-      action: 'tables',
-      db: '/tmp/codebot-no-such-database-12345.db',
+/**
+ * Row 8 — argv shape via buildSqlitePlan(). Pure seam; no sqlite3 needed.
+ * Pinning these is what keeps a future refactor from sliding back into
+ * `execSync(string)` and the double-quote interpolation trap.
+ */
+describe('DatabaseTool — argv shape (Row 8: via buildSqlitePlan)', () => {
+  let workDir: string;
+  let tempDb: string;
+
+  before(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-db-argv-'));
+    tempDb = path.join(workDir, 'argv.db');
+    fs.writeFileSync(tempDb, '', 'utf-8');
+  });
+
+  after(() => {
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('query: db and sql each become discrete argv elements (no shell interpolation)', () => {
+    const tool = new DatabaseTool(workDir);
+    const sql = 'SELECT 1; `touch /tmp/should-not-happen`';
+    const plan = tool.buildSqlitePlan({ action: 'query', db: tempDb, sql });
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.strictEqual(plan.command, 'sqlite3');
+    assert.strictEqual(plan.argv[0], path.resolve(workDir, 'argv.db'));
+    assert.strictEqual(plan.argv[1], sql,
+      'sql must be its own argv element, with backtick literal');
+    assert.ok(!plan.argv.some(a => a.includes('"') && a.includes('sqlite3')),
+      'no element should resemble a pre-quoted shell fragment');
+  });
+
+  it('tables: argv is [db, ".tables"]', () => {
+    const tool = new DatabaseTool(workDir);
+    const plan = tool.buildSqlitePlan({ action: 'tables', db: tempDb });
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.deepStrictEqual(plan.argv, [path.resolve(workDir, 'argv.db'), '.tables']);
+  });
+
+  it('schema with table: identifier validated, joined into one argv element', () => {
+    const tool = new DatabaseTool(workDir);
+    const plan = tool.buildSqlitePlan({ action: 'schema', db: tempDb, table: 'users' });
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.deepStrictEqual(plan.argv, [path.resolve(workDir, 'argv.db'), '.schema users']);
+  });
+
+  it('schema rejects malicious table name (defense-in-depth)', () => {
+    const tool = new DatabaseTool(workDir);
+    const plan = tool.buildSqlitePlan({
+      action: 'schema', db: tempDb, table: 'users; DROP TABLE x',
     });
-    assert.ok(result.includes('Error: database not found'));
+    assert.ok('error' in plan);
+    if ('error' in plan) assert.match(plan.error, /invalid table name/);
+  });
+
+  it('argv element 0 is always the resolved-absolute db path', () => {
+    const tool = new DatabaseTool(workDir);
+    const plan = tool.buildSqlitePlan({ action: 'tables', db: 'argv.db' /* relative */ });
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.strictEqual(plan.argv[0], path.resolve(workDir, 'argv.db'),
+      'relative db must be resolved against projectRoot');
+  });
+});
+
+/**
+ * Row 8 — db-path containment under projectRoot.
+ */
+describe('DatabaseTool — db-path containment (Row 8)', () => {
+  it('rejects db path outside projectRoot (absolute escape)', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-db-contain-'));
+    try {
+      const tool = new DatabaseTool(workDir);
+      const escapeTarget = process.platform === 'win32' ? 'C:\\Windows\\System32\\drivers\\etc\\hosts' : '/etc/passwd';
+      const plan = tool.buildSqlitePlan({ action: 'tables', db: escapeTarget });
+      assert.ok('error' in plan);
+      if ('error' in plan) assert.match(plan.error, /db path escapes project root/);
+    } finally {
+      try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it('rejects db path with parent traversal', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-db-contain-'));
+    try {
+      const tool = new DatabaseTool(workDir);
+      const plan = tool.buildSqlitePlan({ action: 'tables', db: '../../../etc/passwd' });
+      assert.ok('error' in plan);
+      if ('error' in plan) assert.match(plan.error, /db path escapes project root/);
+    } finally {
+      try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it('rejects sibling-prefix db path (not true containment)', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-db-contain-'));
+    try {
+      const sibling = workDir + '-evil/foo.db';
+      const tool = new DatabaseTool(workDir);
+      const plan = tool.buildSqlitePlan({ action: 'tables', db: sibling });
+      assert.ok('error' in plan, 'sibling-prefix must be rejected');
+    } finally {
+      try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+});
+
+/**
+ * Row 8 — real-exec canary. sqlite3 may or may not be installed on the
+ * test host; we don't care. The point is whether a LOCAL shell was
+ * spawned and interpreted the metacharacters BEFORE sqlite3 fired. If
+ * a future refactor reverts to `execSync(string)`, the marker appears.
+ */
+describe('DatabaseTool — local-shell injection canary (real exec)', () => {
+  let workDir: string;
+  let originalCwd: string;
+
+  before(() => {
+    originalCwd = process.cwd();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-db-canary-'));
+    process.chdir(workDir);
+    fs.writeFileSync(path.join(workDir, 'real.db'), '');
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('backticks in sql do not run a local shell', async () => {
+    const marker = path.join(workDir, 'PWNED_SQL_BACKTICK');
+    const tool = new DatabaseTool(workDir);
+    const sql = `SELECT 1; \`node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')"\``;
+    await tool.execute({ action: 'query', db: 'real.db', sql });
+    assert.strictEqual(fs.existsSync(marker), false,
+      `LOCAL SHELL INJECTION REGRESSION via sql backticks: ${marker} was created. Tool reverted to execSync(string).`);
+  });
+
+  it('$(...) in sql does not run a local shell', async () => {
+    const marker = path.join(workDir, 'PWNED_SQL_DOLLAR');
+    const tool = new DatabaseTool(workDir);
+    const sql = `SELECT 1; $(node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')")`;
+    await tool.execute({ action: 'query', db: 'real.db', sql });
+    assert.strictEqual(fs.existsSync(marker), false,
+      `LOCAL SHELL INJECTION REGRESSION via sql $(...): ${marker} was created.`);
   });
 });

--- a/src/tools/database.ts
+++ b/src/tools/database.ts
@@ -1,5 +1,39 @@
-import { execSync } from 'child_process';
+/**
+ * SQLite tool — query / list tables / show schema / db info.
+ *
+ * Row 8 fix (2026-04-24):
+ * Pre-fix every action used `execSync` with a hand-built shell line:
+ *
+ *   execSync(`sqlite3 "${dbPath}" "${command.replace(/"/g, '\\"')}"`)
+ *
+ * Both `dbPath` and `command` (which carries agent-supplied SQL or
+ * dot-meta commands) were placed inside double quotes. Bash expands
+ * `$(...)`, backticks, and `${...}` INSIDE double quotes — and the
+ * `replace(/"/g, '\\"')` only escapes double quotes, not the
+ * substitution metacharacters. So:
+ *
+ *   sql = 'SELECT 1; `touch /tmp/pwned`'
+ *   →  sqlite3 "real.db" "SELECT 1; `touch /tmp/pwned`"
+ *   →  bash expands the backtick LOCALLY before sqlite3 ever sees it.
+ *
+ * `BLOCKED_SQL` was a regex against DROP/DELETE/TRUNCATE — it did not
+ * even attempt to catch shell metacharacters.
+ *
+ * What this file now does:
+ *   - `execFileSync('sqlite3', argv)`. No local shell.
+ *   - `db` path contained under the agent's `projectRoot` (Issue #17
+ *     pattern). Pre-fix the agent could pass `db: '/etc/foo.db'`.
+ *   - `BLOCKED_SQL` kept as defense-in-depth on SQL semantics. With
+ *     argv it doesn't carry security weight against shell injection
+ *     anymore (the shell is gone), but the destructive-statement
+ *     intent is still useful.
+ *   - `buildSqlitePlan()` is a pure seam returning `{command, argv} |
+ *     {error}` so tests pin the argv contract.
+ */
+
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 import { Tool } from '../types';
 
 const BLOCKED_SQL = [
@@ -9,77 +43,123 @@ const BLOCKED_SQL = [
   /\bALTER\s+TABLE\s+.*\bDROP\b/i,
 ];
 
+/**
+ * Decide whether `target` is contained within `root`.
+ * Sibling-prefix safe via path.relative.
+ */
+function isContained(root: string, target: string): boolean {
+  const absRoot = path.resolve(root);
+  const absTarget = path.resolve(target);
+  if (absRoot === absTarget) return true;
+  const rel = path.relative(absRoot, absTarget);
+  if (!rel) return true;
+  if (rel.startsWith('..')) return false;
+  if (path.isAbsolute(rel)) return false;
+  return true;
+}
+
+export type SqlitePlan =
+  | { command: 'sqlite3'; argv: string[] }
+  | { error: string };
+
 export class DatabaseTool implements Tool {
   name = 'database';
   description = 'Query SQLite databases. Actions: query, tables, schema, info. Blocks DROP/DELETE/TRUNCATE for safety.';
   permission: Tool['permission'] = 'prompt';
+  /**
+   * Containment root. Issue #17 pattern: plumbed from `Agent.projectRoot`
+   * via `ToolRegistry`, falls back to `process.cwd()` for back-compat.
+   */
+  private readonly projectRoot: string;
+  constructor(projectRoot?: string) {
+    this.projectRoot = projectRoot || process.cwd();
+  }
   parameters = {
     type: 'object',
     properties: {
       action: { type: 'string', description: 'Action: query, tables, schema, info' },
-      db: { type: 'string', description: 'Path to SQLite database file' },
+      db: { type: 'string', description: 'Path to SQLite database file (must be inside projectRoot)' },
       sql: { type: 'string', description: 'SQL query to execute (for "query" action)' },
       table: { type: 'string', description: 'Table name (for "schema" action)' },
     },
     required: ['action', 'db'],
   };
 
-  async execute(args: Record<string, unknown>): Promise<string> {
-    const action = args.action as string;
-    const dbPath = args.db as string;
+  /**
+   * Pure seam: build the (command, argv) pair without executing.
+   */
+  public buildSqlitePlan(args: Record<string, unknown>): SqlitePlan {
+    const action = args.action;
+    const dbArg = args.db;
+    if (typeof action !== 'string' || action.length === 0) return { error: 'Error: action is required' };
+    if (typeof dbArg !== 'string' || dbArg.length === 0) return { error: 'Error: db path is required' };
 
-    if (!action) return 'Error: action is required';
-    if (!dbPath) return 'Error: db path is required';
-    if (!fs.existsSync(dbPath)) return `Error: database not found: ${dbPath}`;
+    const dbResolved = path.resolve(this.projectRoot, dbArg);
+    if (!isContained(this.projectRoot, dbResolved)) {
+      return { error: `Error: db path escapes project root (${dbResolved} not under ${this.projectRoot})` };
+    }
 
     switch (action) {
-      case 'query': return this.runQuery(dbPath, args);
-      case 'tables': return this.listTables(dbPath);
-      case 'schema': return this.showSchema(dbPath, args);
-      case 'info': return this.dbInfo(dbPath);
-      default: return `Error: unknown action "${action}". Use: query, tables, schema, info`;
-    }
-  }
-
-  private runQuery(dbPath: string, args: Record<string, unknown>): string {
-    const sql = args.sql as string;
-    if (!sql) return 'Error: sql is required for query';
-
-    // Block destructive queries
-    for (const pattern of BLOCKED_SQL) {
-      if (pattern.test(sql)) {
-        return `Error: destructive SQL blocked for safety. Pattern matched: ${pattern.source}`;
+      case 'query': {
+        const sql = args.sql;
+        if (typeof sql !== 'string' || sql.length === 0) return { error: 'Error: sql is required for query' };
+        for (const pattern of BLOCKED_SQL) {
+          if (pattern.test(sql)) {
+            return { error: `Error: destructive SQL blocked for safety. Pattern matched: ${pattern.source}` };
+          }
+        }
+        // sqlite3 <db> <statement> — both as their own argv elements.
+        // Metacharacters inside `sql` stay literal: they reach sqlite3's
+        // SQL parser, not bash.
+        return { command: 'sqlite3', argv: [dbResolved, sql] };
       }
+      case 'tables':
+        return { command: 'sqlite3', argv: [dbResolved, '.tables'] };
+      case 'schema': {
+        const table = args.table;
+        if (typeof table === 'string' && table.length > 0) {
+          // Identifier validation kept as defense-in-depth — sqlite3's
+          // .schema parser will reject odd input anyway, but a strict
+          // SQL identifier is a clean policy-level rule.
+          if (!/^[a-zA-Z_]\w*$/.test(table)) {
+            return { error: 'Error: invalid table name' };
+          }
+          return { command: 'sqlite3', argv: [dbResolved, `.schema ${table}`] };
+        }
+        return { command: 'sqlite3', argv: [dbResolved, '.schema'] };
+      }
+      case 'info':
+        return { command: 'sqlite3', argv: [dbResolved, "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"] };
+      default:
+        return { error: `Error: unknown action "${action}". Use: query, tables, schema, info` };
+    }
+  }
+
+  async execute(args: Record<string, unknown>): Promise<string> {
+    const plan = this.buildSqlitePlan(args);
+    if ('error' in plan) return plan.error;
+
+    // Existence check on the resolved db path. sqlite3 will create a file
+    // if it doesn't exist, which we don't want for read-style actions.
+    // The `info` action also wants stat() data, so we resolve once here.
+    const dbResolved = plan.argv[0];
+    if (!fs.existsSync(dbResolved)) {
+      return `Error: database not found: ${dbResolved}`;
     }
 
-    return this.sqlite(dbPath, sql);
-  }
-
-  private listTables(dbPath: string): string {
-    return this.sqlite(dbPath, ".tables");
-  }
-
-  private showSchema(dbPath: string, args: Record<string, unknown>): string {
-    const table = args.table as string;
-    if (table) {
-      // Sanitize table name
-      if (!/^[a-zA-Z_]\w*$/.test(table)) return 'Error: invalid table name';
-      return this.sqlite(dbPath, `.schema ${table}`);
+    if ((args.action as string) === 'info') {
+      const stat = fs.statSync(dbResolved);
+      const sizeMB = (stat.size / (1024 * 1024)).toFixed(2);
+      const tables = this.runPlan(plan);
+      return `Database: ${dbResolved}\nSize: ${sizeMB} MB\nModified: ${stat.mtime.toISOString()}\n\nTables:\n${tables}`;
     }
-    return this.sqlite(dbPath, ".schema");
+
+    return this.runPlan(plan);
   }
 
-  private dbInfo(dbPath: string): string {
-    const stat = fs.statSync(dbPath);
-    const sizeMB = (stat.size / (1024 * 1024)).toFixed(2);
-    const tables = this.sqlite(dbPath, "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;");
-    return `Database: ${dbPath}\nSize: ${sizeMB} MB\nModified: ${stat.mtime.toISOString()}\n\nTables:\n${tables}`;
-  }
-
-  private sqlite(dbPath: string, command: string): string {
+  private runPlan(plan: { command: 'sqlite3'; argv: string[] }): string {
     try {
-      // Try sqlite3 CLI first
-      const output = execSync(`sqlite3 "${dbPath}" "${command.replace(/"/g, '\\"')}"`, {
+      const output = execFileSync(plan.command, plan.argv, {
         timeout: 15_000,
         maxBuffer: 1024 * 1024,
         encoding: 'utf-8',
@@ -87,11 +167,11 @@ export class DatabaseTool implements Tool {
       });
       return output.trim() || '(no results)';
     } catch (err: unknown) {
-      const e = err as { stderr?: string };
-      const msg = (e.stderr || '').trim();
-      if (msg.includes('not found')) {
+      const e = err as { code?: string; stderr?: string };
+      if (e.code === 'ENOENT') {
         return 'Error: sqlite3 is not installed. Install it with: brew install sqlite (macOS) or apt install sqlite3 (Linux)';
       }
+      const msg = (e.stderr || '').trim();
       return `Error: ${msg || 'query failed'}`;
     }
   }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -163,11 +163,11 @@ export class ToolRegistry {
     regIf(new TaskPlannerTool());
     regIf(new DiffViewerTool());
     regIf(new DockerTool());
-    regIf(new DatabaseTool());
+    regIf(new DatabaseTool(projectRoot));
     regIf(new TestRunnerTool(projectRoot));
     regIf(new HttpClientTool());
     regIf(new ImageInfoTool());
-    regIf(new SshRemoteTool());
+    regIf(new SshRemoteTool(projectRoot));
     regIf(new NotificationTool());
     regIf(new PdfExtractTool());
     regIf(new PackageManagerTool());

--- a/src/tools/ssh-remote.test.ts
+++ b/src/tools/ssh-remote.test.ts
@@ -1,5 +1,8 @@
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { SshRemoteTool } from './ssh-remote';
 
 /**
@@ -188,5 +191,241 @@ describe('SshRemoteTool — command injection via host (regression)', () => {
       command: 'ls',
     });
     assert.ok(result.includes('Error: host contains invalid characters'));
+  });
+});
+
+/**
+ * Row 8 fix (2026-04-24): pre-fix, every action used `execSync(string)`
+ * with agent-supplied `command`, `local_path`, and `remote_path`
+ * concatenated raw. The `JSON.stringify(cmd)` wrapper looked like
+ * quoting, but it produces double-quoted strings — and bash expands
+ * `$(...)`, backticks, and `${...}` INSIDE double quotes. So:
+ *
+ *   command = '$(touch /tmp/pwned)'
+ *   →  ssh ... "$(touch /tmp/pwned)"
+ *   →  bash expands $(...) LOCALLY before ssh fires.
+ *
+ * Security claim of these tests:
+ *   - argv-based exec removes the LOCAL shell from the loop. Hostile
+ *     metacharacters in command/local_path/remote_path cannot create
+ *     a marker file on the agent's machine.
+ *   - The remote command (when ssh succeeds) still goes through the
+ *     remote shell by SSH protocol design — that's a feature, not a
+ *     bug, and not the threat model here.
+ *   - `local_path` is contained under `projectRoot`. Pre-fix the agent
+ *     could read /etc/shadow via download or write any path via upload.
+ */
+
+describe('SshRemoteTool — argv shape (Row 8: via buildPlan)', () => {
+  it('exec: command stays as a single argv element, never interpolated', () => {
+    const tool = new SshRemoteTool();
+    const payload = '$(touch /tmp/should-not-happen)';
+    const plan = tool.buildPlan({
+      action: 'exec', host: 'alice@host', command: payload,
+    });
+    assert.ok(!('error' in plan));
+    if ('error' in plan) return;
+    assert.strictEqual(plan.command, 'ssh');
+    assert.strictEqual(plan.argv[plan.argv.length - 2], 'alice@host');
+    assert.strictEqual(plan.argv[plan.argv.length - 1], payload,
+      'command must be the last argv element, literal');
+  });
+
+  it('exec: -p flag only added for non-default port', () => {
+    const tool = new SshRemoteTool();
+    const planDefault = tool.buildPlan({
+      action: 'exec', host: 'h', command: 'ls',
+    });
+    const plan2222 = tool.buildPlan({
+      action: 'exec', host: 'h', command: 'ls', port: 2222,
+    });
+    if ('error' in planDefault || 'error' in plan2222) {
+      throw new Error('expected both to plan');
+    }
+    assert.ok(!planDefault.argv.includes('-p'));
+    assert.ok(plan2222.argv.includes('-p'));
+    assert.strictEqual(plan2222.argv[plan2222.argv.indexOf('-p') + 1], '2222');
+  });
+
+  it('port: rejects non-number (Row 8 P3-style strict typing)', () => {
+    const tool = new SshRemoteTool();
+    const plan = tool.buildPlan({
+      action: 'exec', host: 'h', command: 'ls',
+      port: '22; rm -rf ~' as unknown as number,
+    });
+    assert.ok('error' in plan);
+    if ('error' in plan) assert.match(plan.error, /port must be an integer/);
+  });
+
+  it('port: rejects out-of-range', () => {
+    const tool = new SshRemoteTool();
+    const plan = tool.buildPlan({
+      action: 'exec', host: 'h', command: 'ls', port: 99999,
+    });
+    assert.ok('error' in plan);
+  });
+
+  it('upload: local resolved absolute, host:remote stays one argv element', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-ssh-'));
+    try {
+      fs.writeFileSync(path.join(workDir, 'src.txt'), 'hi');
+      const t = new SshRemoteTool(workDir);
+      const plan = t.buildPlan({
+        action: 'upload', host: 'h', local_path: 'src.txt', remote_path: '/dst/file',
+      });
+      assert.ok(!('error' in plan));
+      if ('error' in plan) return;
+      assert.strictEqual(plan.command, 'scp');
+      assert.ok(plan.argv.includes(path.resolve(workDir, 'src.txt')),
+        'local must be resolved absolute');
+      assert.ok(plan.argv.includes('h:/dst/file'),
+        'remote target must be one argv element of form host:remote');
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it('download: argv order is (..opts.., remote, local)', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-ssh-'));
+    try {
+      const t = new SshRemoteTool(workDir);
+      const plan = t.buildPlan({
+        action: 'download', host: 'h', local_path: 'dst.txt', remote_path: '/src/file',
+      });
+      assert.ok(!('error' in plan));
+      if ('error' in plan) return;
+      const remoteIdx = plan.argv.findIndex(a => a === 'h:/src/file');
+      const localIdx = plan.argv.findIndex(a => a === path.resolve(workDir, 'dst.txt'));
+      assert.ok(remoteIdx >= 0 && localIdx >= 0 && remoteIdx < localIdx,
+        'scp download argv must be (..opts.., remote, local)');
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('SshRemoteTool — local_path containment (Row 8)', () => {
+  it('upload rejects local_path that escapes projectRoot', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-ssh-'));
+    try {
+      const t = new SshRemoteTool(workDir);
+      const plan = t.buildPlan({
+        action: 'upload', host: 'h', local_path: '../../../etc/passwd', remote_path: '/dst',
+      });
+      assert.ok('error' in plan);
+      if ('error' in plan) assert.match(plan.error, /local_path escapes project root/);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it('download rejects absolute local_path outside projectRoot', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-ssh-'));
+    try {
+      const t = new SshRemoteTool(workDir);
+      const escapeTarget = process.platform === 'win32' ? 'C:\\Windows\\evil.txt' : '/etc/cron.d/evil';
+      const plan = t.buildPlan({
+        action: 'download', host: 'h', local_path: escapeTarget, remote_path: '/src',
+      });
+      assert.ok('error' in plan);
+      if ('error' in plan) assert.match(plan.error, /local_path escapes project root/);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it('upload: sibling-prefix local_path rejected (not true containment)', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-ssh-'));
+    try {
+      const sibling = workDir + '-evil'; // shares prefix but is a different dir
+      const t = new SshRemoteTool(workDir);
+      const plan = t.buildPlan({
+        action: 'upload', host: 'h', local_path: sibling, remote_path: '/dst',
+      });
+      assert.ok('error' in plan, 'sibling-prefix must be rejected');
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * Real-exec canaries. ssh/scp will fail (ENOENT, dns-error, auth-error)
+ * — that's fine. We only care whether a LOCAL shell was spawned and
+ * interpreted the metacharacters before that. If a future refactor
+ * reverts to `execSync(string)`, the marker file appears.
+ */
+describe('SshRemoteTool — local-shell injection canaries (real exec)', () => {
+  let workDir: string;
+  let originalCwd: string;
+
+  before(() => {
+    originalCwd = process.cwd();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebot-row8-ssh-canary-'));
+    process.chdir(workDir);
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('exec: $(...) in command does not run locally', async () => {
+    const marker = path.join(workDir, 'PWNED_SSH_EXEC');
+    const tool = new SshRemoteTool(workDir);
+    const payload = `$(node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')")`;
+    await tool.execute({
+      action: 'exec',
+      host: '127.0.0.1',
+      port: 1,
+      command: payload,
+    });
+    assert.strictEqual(fs.existsSync(marker), false,
+      `LOCAL SHELL INJECTION REGRESSION: ${marker} was created via command. Tool reverted to execSync(string).`);
+  });
+
+  it('exec: backticks in command do not run locally', async () => {
+    const marker = path.join(workDir, 'PWNED_SSH_BACKTICK');
+    const tool = new SshRemoteTool(workDir);
+    const payload = `\`node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')"\``;
+    await tool.execute({
+      action: 'exec',
+      host: '127.0.0.1',
+      port: 1,
+      command: payload,
+    });
+    assert.strictEqual(fs.existsSync(marker), false,
+      `LOCAL SHELL INJECTION REGRESSION via backticks: ${marker} was created.`);
+  });
+
+  it('upload: shell metacharacters in remote_path do not run locally', async () => {
+    const marker = path.join(workDir, 'PWNED_SCP_REMOTE');
+    fs.writeFileSync(path.join(workDir, 'src.txt'), 'hi');
+    const tool = new SshRemoteTool(workDir);
+    const evilRemote = `/dst"; node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')" #`;
+    await tool.execute({
+      action: 'upload',
+      host: '127.0.0.1',
+      port: 1,
+      local_path: 'src.txt',
+      remote_path: evilRemote,
+    });
+    assert.strictEqual(fs.existsSync(marker), false,
+      `LOCAL SHELL INJECTION REGRESSION via remote_path: ${marker} was created.`);
+  });
+
+  it('download: shell metacharacters in remote_path do not run locally', async () => {
+    const marker = path.join(workDir, 'PWNED_SCP_DOWNLOAD');
+    const tool = new SshRemoteTool(workDir);
+    const evilRemote = `/src"; node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}','pwned')" #`;
+    await tool.execute({
+      action: 'download',
+      host: '127.0.0.1',
+      port: 1,
+      local_path: 'dst.txt',
+      remote_path: evilRemote,
+    });
+    assert.strictEqual(fs.existsSync(marker), false,
+      `LOCAL SHELL INJECTION REGRESSION via download remote_path: ${marker} was created.`);
   });
 });

--- a/src/tools/ssh-remote.ts
+++ b/src/tools/ssh-remote.ts
@@ -1,64 +1,176 @@
-import { execSync } from 'child_process';
+/**
+ * SSH/SCP remote-execution tool.
+ *
+ * Row 8 fix (2026-04-24):
+ * Pre-fix, every action used `execSync(string)` with agent-supplied
+ * `command`, `local_path`, and `remote_path` concatenated raw into a
+ * shell line. The `JSON.stringify(cmd)` wrapper looked like quoting,
+ * but it produces double-quoted strings — and bash expands `$(...)`,
+ * backticks, and `${...}` INSIDE double quotes. So:
+ *
+ *   command = '$(touch /tmp/pwned)'
+ *   →  ssh ... host "$(touch /tmp/pwned)"
+ *   →  bash expands $(...) LOCALLY, runs `touch`, then sends the
+ *      empty result over ssh.
+ *
+ * Same shape for `scp ... "${local}" ${host}:"${remote}"` — `local`
+ * and `remote` were entirely unvalidated.
+ *
+ * Security claim of this fix: **argv-based exec removes the LOCAL
+ * shell from the loop**. Metacharacters in `command`, `local_path`,
+ * and `remote_path` cannot trigger code execution on the agent's
+ * machine. The remote command still passes through the REMOTE shell
+ * by SSH protocol design — that's how `ssh host "ls /tmp"` is
+ * supposed to work, and we are not in the business of sandboxing the
+ * remote box. The user/policy decides whether they trust the host.
+ *
+ * What this file now does:
+ *   - `execFileSync('ssh' | 'scp', argv)`. No local shell.
+ *   - `host` still validated by `SAFE_HOST` (defense-in-depth on the
+ *     SSH target, since some malformed hosts would otherwise hit
+ *     OpenSSH's own shell-out paths via ProxyCommand expansion).
+ *   - `local_path` for upload/download is contained under the agent's
+ *     declared `projectRoot` (Issue #17 pattern). Pre-fix, the agent
+ *     could read `/etc/shadow` via download or write into any path
+ *     via upload.
+ *   - `buildSshArgv()` / `buildScpArgv()` are pure seams returning
+ *     `{command, argv} | {error}` so tests pin the argv contract.
+ */
+
+import { execFileSync } from 'child_process';
+import * as path from 'path';
 import { Tool } from '../types';
 
-// Block shell injection characters in host/user inputs
+// Block injection-y characters in host/user inputs. Even argv-only execs
+// pipe `host` to OpenSSH's config parser, where ProxyCommand and similar
+// directives can shell-out — keeping host strict closes that side door.
 const SAFE_HOST = /^[a-zA-Z0-9._\-@:]+$/;
+
+/**
+ * Decide whether `target` is contained within `root`.
+ * Sibling-prefix safe via path.relative.
+ */
+function isContained(root: string, target: string): boolean {
+  const absRoot = path.resolve(root);
+  const absTarget = path.resolve(target);
+  if (absRoot === absTarget) return true;
+  const rel = path.relative(absRoot, absTarget);
+  if (!rel) return true;
+  if (rel.startsWith('..')) return false;
+  if (path.isAbsolute(rel)) return false;
+  return true;
+}
+
+export type SshPlan =
+  | { command: 'ssh' | 'scp'; argv: string[] }
+  | { error: string };
 
 export class SshRemoteTool implements Tool {
   name = 'ssh_remote';
   description = 'Execute commands on remote servers via SSH, or upload/download files via SCP. Actions: exec, upload, download.';
   permission: Tool['permission'] = 'always-ask';
+  /**
+   * Containment root for local paths (upload source, download target).
+   * Issue #17 pattern: plumbed from `Agent.projectRoot` via `ToolRegistry`,
+   * falls back to `process.cwd()` for back-compat.
+   */
+  private readonly projectRoot: string;
+  constructor(projectRoot?: string) {
+    this.projectRoot = projectRoot || process.cwd();
+  }
   parameters = {
     type: 'object',
     properties: {
       action: { type: 'string', description: 'Action: exec, upload, download' },
       host: { type: 'string', description: 'SSH target (user@hostname or hostname)' },
       command: { type: 'string', description: 'Command to execute remotely (for exec)' },
-      local_path: { type: 'string', description: 'Local file path (for upload/download)' },
+      local_path: { type: 'string', description: 'Local file path — must be inside projectRoot (for upload/download)' },
       remote_path: { type: 'string', description: 'Remote file path (for upload/download)' },
       port: { type: 'number', description: 'SSH port (default: 22)' },
     },
     required: ['action', 'host'],
   };
 
-  async execute(args: Record<string, unknown>): Promise<string> {
+  /**
+   * Pure seam: build the (command, argv) pair without executing.
+   * Lets tests pin the argv contract without stubbing child_process.
+   */
+  public buildPlan(args: Record<string, unknown>): SshPlan {
     const action = args.action as string;
     const host = args.host as string;
+    if (!action) return { error: 'Error: action is required' };
+    if (!host) return { error: 'Error: host is required' };
+    if (!SAFE_HOST.test(host)) {
+      return { error: 'Error: host contains invalid characters (possible injection)' };
+    }
 
-    if (!action) return 'Error: action is required';
-    if (!host) return 'Error: host is required';
-    if (!SAFE_HOST.test(host)) return 'Error: host contains invalid characters (possible injection)';
+    // port: strict number, in [1, 65535]
+    let port = 22;
+    if (args.port !== undefined && args.port !== null) {
+      if (typeof args.port !== 'number' || !Number.isInteger(args.port) || args.port < 1 || args.port > 65535) {
+        return { error: 'Error: port must be an integer in [1, 65535]' };
+      }
+      port = args.port;
+    }
 
-    const port = (args.port as number) || 22;
-    const portFlag = port !== 22 ? `-p ${port}` : '';
-    const scpPortFlag = port !== 22 ? `-P ${port}` : '';
+    const sshOpts = ['-o', 'ConnectTimeout=10', '-o', 'StrictHostKeyChecking=accept-new'];
 
     switch (action) {
       case 'exec': {
-        const cmd = args.command as string;
-        if (!cmd) return 'Error: command is required for exec';
-        return this.runSsh(`ssh ${portFlag} -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new ${host} ${JSON.stringify(cmd)}`);
+        const cmd = args.command;
+        if (typeof cmd !== 'string' || cmd.length === 0) {
+          return { error: 'Error: command is required for exec' };
+        }
+        const portArg = port !== 22 ? ['-p', String(port)] : [];
+        // argv: [..opts, host, cmd]. ssh sends `cmd` to the remote shell
+        // verbatim — that's by SSH design. Our claim is only about the
+        // local exec.
+        return { command: 'ssh', argv: [...sshOpts, ...portArg, host, cmd] };
       }
       case 'upload': {
-        const local = args.local_path as string;
-        const remote = args.remote_path as string;
-        if (!local || !remote) return 'Error: local_path and remote_path are required';
-        return this.runSsh(`scp ${scpPortFlag} -o ConnectTimeout=10 "${local}" ${host}:"${remote}"`);
+        const local = args.local_path;
+        const remote = args.remote_path;
+        if (typeof local !== 'string' || local.length === 0 || typeof remote !== 'string' || remote.length === 0) {
+          return { error: 'Error: local_path and remote_path are required' };
+        }
+        const localResolved = path.resolve(this.projectRoot, local);
+        if (!isContained(this.projectRoot, localResolved)) {
+          return { error: `Error: local_path escapes project root (${localResolved} not under ${this.projectRoot})` };
+        }
+        const portArg = port !== 22 ? ['-P', String(port)] : [];
+        // SCP target spec is `host:remote`. We assemble it as a single
+        // argv element so a malicious `host` containing spaces or a
+        // malicious `remote` with metacharacters cannot split it.
+        // `host` is SAFE_HOST-validated; `remote` may contain anything,
+        // but it stays inside one argv element and never sees a local
+        // shell. The remote SCP server interprets it on the other end —
+        // again, that's the protocol's design.
+        return { command: 'scp', argv: [...sshOpts, ...portArg, localResolved, `${host}:${remote}`] };
       }
       case 'download': {
-        const local = args.local_path as string;
-        const remote = args.remote_path as string;
-        if (!local || !remote) return 'Error: local_path and remote_path are required';
-        return this.runSsh(`scp ${scpPortFlag} -o ConnectTimeout=10 ${host}:"${remote}" "${local}"`);
+        const local = args.local_path;
+        const remote = args.remote_path;
+        if (typeof local !== 'string' || local.length === 0 || typeof remote !== 'string' || remote.length === 0) {
+          return { error: 'Error: local_path and remote_path are required' };
+        }
+        const localResolved = path.resolve(this.projectRoot, local);
+        if (!isContained(this.projectRoot, localResolved)) {
+          return { error: `Error: local_path escapes project root (${localResolved} not under ${this.projectRoot})` };
+        }
+        const portArg = port !== 22 ? ['-P', String(port)] : [];
+        return { command: 'scp', argv: [...sshOpts, ...portArg, `${host}:${remote}`, localResolved] };
       }
       default:
-        return `Error: unknown action "${action}". Use: exec, upload, download`;
+        return { error: `Error: unknown action "${action}". Use: exec, upload, download` };
     }
   }
 
-  private runSsh(cmd: string): string {
+  async execute(args: Record<string, unknown>): Promise<string> {
+    const plan = this.buildPlan(args);
+    if ('error' in plan) return plan.error;
+
     try {
-      const output = execSync(cmd, {
+      const output = execFileSync(plan.command, plan.argv, {
         timeout: 60_000,
         maxBuffer: 2 * 1024 * 1024,
         encoding: 'utf-8',
@@ -67,7 +179,7 @@ export class SshRemoteTool implements Tool {
       return output.trim() || '(no output)';
     } catch (err: unknown) {
       const e = err as { status?: number; stderr?: string };
-      const msg = (e.stderr || 'SSH command failed').trim();
+      const msg = (e.stderr || `${plan.command} command failed`).trim();
       if (msg.includes('Connection refused') || msg.includes('Connection timed out')) {
         return `Error: could not connect to host. ${msg}`;
       }

--- a/src/tools/tools.test.ts
+++ b/src/tools/tools.test.ts
@@ -476,7 +476,11 @@ describe('DiffViewerTool', () => {
 });
 
 describe('DatabaseTool', () => {
-  const tmpDb = path.join(os.tmpdir(), `codebot-test-${Date.now()}.db`);
+  // Row 8 fix: db path is now contained under projectRoot. Construct the
+  // registry with projectRoot=os.tmpdir() so the test fixture under
+  // os.tmpdir() is inside the policy boundary.
+  const dbDir = os.tmpdir();
+  const tmpDb = path.join(dbDir, `codebot-test-${Date.now()}.db`);
 
   before(() => {
     // Create an empty file to pass existence check
@@ -492,24 +496,26 @@ describe('DatabaseTool', () => {
   });
 
   it('blocks destructive SQL', async () => {
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry(dbDir);
     const tool = registry.get('database')!;
     const result = await tool.execute({ action: 'query', db: tmpDb, sql: 'DROP TABLE users' });
     assert.ok(result.includes('blocked'), `Expected "blocked" in: ${result}`);
   });
 
   it('blocks DELETE FROM', async () => {
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry(dbDir);
     const tool = registry.get('database')!;
     const result = await tool.execute({ action: 'query', db: tmpDb, sql: 'DELETE FROM users WHERE id=1' });
     assert.ok(result.includes('blocked'), `Expected "blocked" in: ${result}`);
   });
 
-  it('returns error for missing db', async () => {
-    const registry = new ToolRegistry();
+  it('returns error for missing db (inside projectRoot)', async () => {
+    const registry = new ToolRegistry(dbDir);
     const tool = registry.get('database')!;
-    const result = await tool.execute({ action: 'tables', db: '/nonexistent/db.sqlite' });
-    assert.ok(result.includes('Error: database not found'));
+    const missing = path.join(dbDir, `codebot-missing-${Date.now()}.sqlite`);
+    const result = await tool.execute({ action: 'tables', db: missing });
+    assert.ok(result.includes('Error: database not found'),
+      `Expected "Error: database not found" in: ${result}`);
   });
 });
 


### PR DESCRIPTION
Part of the Row 8 / Row 9 security sweep. PR-A: SSH + DB only. PR-B will handle DockerTool + PackageManagerTool.

## Summary

Both tools assembled `execSync(string)` from agent-supplied inputs concatenated raw inside double quotes. Bash expands `\$(...)`, backticks, and `\${...}` **inside double quotes** — the existing defenses didn't address that.

| Tool | Pre-fix sink | Bypass |
|---|---|---|
| `SshRemoteTool.execute` (exec) | `ssh ... \${host} \${JSON.stringify(cmd)}` | `JSON.stringify('\$(touch /tmp/pwned)')` produces `"\$(...)"` — bash expands the substitution **locally** before ssh fires. |
| `SshRemoteTool.execute` (upload/download) | `scp ... "\${local}" \${host}:"\${remote}"` | `local_path` and `remote_path` pasted raw into double quotes; quote breakout + `\$(...)` both work. |
| `DatabaseTool.sqlite` | `sqlite3 "\${dbPath}" "\${sql.replace(/"/g, '\\\\"')}"` | The escape only handled `"`, not backticks or `\$(...)`. `sql = 'SELECT 1; \`touch /tmp/pwned\`'` ran the backtick locally. |

## Fix

- `execFileSync(command, argv)`. No local shell. Pure `buildPlan()` / `buildSqlitePlan()` seams so tests pin the argv contract without stubbing `child_process`.
- `port` is strict `typeof === 'number'` integer in [1, 65535] (rejects strings, NaN, out-of-range — Row 12 P3 pattern).
- `local_path` (ssh upload/download) and `db` (sqlite) contained under `projectRoot` (Issue #17 pattern). Optional constructor arg; `ToolRegistry` passes `Agent.projectRoot`; falls back to `process.cwd()` for back-compat.
- `SAFE_HOST` regex kept (defense-in-depth; malformed hosts can hit OpenSSH's ProxyCommand expansion path).
- `BLOCKED_SQL` regex kept (defense-in-depth on SQL semantics; with argv it no longer carries security weight against shell injection).
- Permissions unchanged: `ssh_remote` stays `always-ask`, `database` stays `prompt`. Central audit logging unchanged.

## Security claim — precise

argv-based exec removes the **local** shell from the loop. Hostile metacharacters in `command` / `local_path` / `remote_path` / `db` / `sql` cannot trigger code execution on the agent's machine.

The remote SSH command **still** passes through the remote shell by protocol design — that's how `ssh host "ls"` is supposed to work, and not the threat model of this fix. The user/policy decides whether they trust the host. SCP target spec stays one argv element so a malicious `host` (already SAFE_HOST-validated) can't split it.

## Out of scope (deliberate)

- **DockerTool + PackageManagerTool** — same shell-injection class, will land in PR-B (Row 9). Per-PR scope agreed before coding.
- **better-sqlite3 library swap** — bigger change. Argv fix here closes the bypass; library swap is a separate "drop the CLI dependency" decision.
- **Policy preset changes** — both tools already gated correctly in research/viewer presets.

## Verification

- [x] `npm run build` — clean tsc
- [x] `node --test dist/tools/ssh-remote.test.js` — **35/35 pass** (was ~25, +10 Row 8 tests)
  - argv shape via `buildPlan` (5)
  - `local_path` containment (3)
  - real-exec canaries: `\$(...)` in command, backticks in command, evil `remote_path` on upload + download (4)
- [x] `node --test dist/tools/database.test.js` — **28/28 pass** (was ~17, +11 Row 8 tests)
  - argv shape via `buildSqlitePlan` (5)
  - `db`-path containment, sibling-prefix safe (3)
  - real-exec canaries: backticks + `\$(...)` in sql (2)
  - DB fixture updated to `mkdtempSync` + `projectRoot`
- [x] `node --test dist/tools/tools.test.js` — 73/73 (no regression; DatabaseTool fixtures in regression suite also updated)
- [x] `node --test dist/tools/test-runner.test.js` → 14/14, `dist/tools/graphics.test.js` → 44/44, `dist/symbol-indexer.test.js` → 11/11 (prior security rows + Issue #11 unaffected)
- [x] `npx eslint` on the 5 source/test files I authored — 0 warnings, 0 errors
- [ ] CI matrix Linux/macOS/Windows × Node 18/20/22 — should stay all-green per Issue #11 closure

## Acceptance

- malicious SSH command/local_path/remote_path → no local marker files
- malicious SQL backticks/`\$()` → no marker files
- DB path outside projectRoot → rejected
- upload/download `local_path` outside projectRoot → rejected
- existing tool regression green
- full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)