### PR TITLE
[INFRA] PR 2: CapabilityLabel union + optional capabilities? on Tool (metadata only)

### DIFF
--- a/docs/personal-agent-infrastructure.md
+++ b/docs/personal-agent-infrastructure.md
@@ -105,7 +105,7 @@ These are the load-bearing rules. New code that violates one is rejected at revi
 │ ToolRegistry: src/tools/index.ts                                 │  (4)
 │   - capability gate, projectRoot plumbing, vault-mode filter     │
 ├──────────────────────────────────────────────────────────────────┤
-│ Tools (35 today): file I/O, exec, browser, connectors, ...      │  (5)
+│ Tools (36 today): file I/O, exec, browser, connectors, ...      │  (5)
 │   - each declares permission, capability label (NEW — see §7)   │
 ├──────────────────────────────────────────────────────────────────┤
 │ Capability layer (NEW — see §7)                                  │  (6)
@@ -194,7 +194,7 @@ Every tool gets one or more capability labels. Labels are **declarative metadata
 
 ### Migration path
 
-Labels do not yet exist on the `Tool` interface. Adding them is a metadata-only change — no behavior change in the tools themselves, no new gating until the agent loop reads the labels. See §10 for the rollout.
+The `CapabilityLabel` type and the optional `capabilities?: CapabilityLabel[]` slot on the `Tool` interface **landed in PR 2** (`src/types.ts`). No tool declares any labels yet; no code reads the field. PR 3 populates labels on each existing tool (mechanical). PR 4 wires the agent loop to read the field and apply per-label gating per the table above. Visibility to the model (via `ToolSchema`) is a separate later decision — PR 2 deliberately does not expose `capabilities` to the LLM. See §10 for the full rollout.
 
 ## 8. Connector roadmap
 
@@ -264,7 +264,7 @@ The doc itself does not change behavior. The execution order to actually build t
 
 1. **PR 1 — this doc.** Architecture commitment, no code change. ← *this PR*
 2. **PR 2 — capability labels on `Tool` interface (metadata only).** Adds optional `capabilities?: CapabilityLabel[]` to `Tool`. Existing tools keep working with no labels declared. No gate change. Pure type addition. ~50 lines.
-3. **PR 3 — declare capability labels on existing 35 tools.** Mechanical. Each tool gets its label list. No behavior change. Reviewable in one sitting because it's a table.
+3. **PR 3 — declare capability labels on existing 36 tools.** Mechanical. Each tool gets its label list. No behavior change. Reviewable in one sitting because it's a table.
 4. **PR 4 — agent loop reads capabilities, escalates `permission` to `always-ask` when label demands it.** This is where capability labels start gating. Tests pin which (tool, action) combos require always-ask.
 5. **PR 5 — model router skeleton.** Pure decision-table function `pickModel(taskClass, sensitivity, budgetRemaining)`. Consumed by the agent loop. Replaces the current single-model selection.
 6. **PR 6 — budget controls.** Per-session cap, escalation logging, summarize-on-overflow. Wired into the router.
@@ -323,4 +323,4 @@ This rule applies to this file, not the broader codebase. Other docs may rot at 
 
 ---
 
-*Last updated 2026-04-25 (third pass: resolved spend-money vs. ordering contradiction by splitting `move-money` PROHIBITED from `spend-money` always-ask; reframed Phase 2 ordering as one example of the general high-risk browser-write class; fixed stale section refs after the §3 insertion). Earlier passes: 2026-04-24 user-owned multi-device-over-time vision; 2026-04-24 engineering-contract discipline (anti-premature-abstraction, doc-rot rule, measurement, connector contract). Against `main @ de6cad7`.*
+*Last updated 2026-04-25 (PR 2 landed: `CapabilityLabel` union and optional `capabilities?` slot now live on `Tool` in `src/types.ts`; tool count corrected 35 → 36 to reflect actual `ToolRegistry` registration; §7 migration-path note updated to reflect that the slot exists). Earlier passes: 2026-04-25 split `move-money` (PROHIBITED) from `spend-money` (always-ask) and reframed Phase 2; 2026-04-24 engineering-contract discipline; 2026-04-24 user-owned multi-device-over-time vision. Against `main @ b8a5433` + this PR.*

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,12 +45,46 @@ export interface ToolStreamResult {
   timedOut: boolean;
 }
 
+/**
+ * Capability labels (§7 of `docs/personal-agent-infrastructure.md`).
+ *
+ * PR 2 — metadata only. The slot exists on `Tool` but no tool declares
+ * a value yet, and no code reads it. PR 3 populates labels on each
+ * existing tool. PR 4 wires the agent loop to gate on them per §7.
+ *
+ * Adding labels here is a doc-rot triggering change: any new label or
+ * removal of an existing label must be reflected in §7 of the
+ * architecture doc in the same PR (§13 doc-rot rule).
+ */
+export type CapabilityLabel =
+  | 'read-only'
+  | 'write-fs'
+  | 'run-cmd'
+  | 'browser-read'
+  | 'browser-write'
+  | 'net-fetch'
+  | 'account-access'
+  | 'send-on-behalf'   // always-ask (§7)
+  | 'delete-data'      // always-ask (§7)
+  | 'spend-money'      // always-ask + preview required (§7)
+  | 'move-money';      // PROHIBITED — tools/connectors with this label must not be usable (§7)
+
 export interface Tool {
   name: string;
   description: string;
   parameters: Record<string, unknown>;
   permission: 'auto' | 'prompt' | 'always-ask';
   cacheable?: boolean;
+  /**
+   * Declared capability labels (PR 2: metadata only).
+   *
+   * Optional during the rollout so existing tools compile without
+   * change. PR 3 declares labels on each tool. PR 4 has the agent
+   * loop read this and apply per-label gating per §7. Visibility to
+   * the model (via `ToolSchema`) is a separate later decision — PR 2
+   * does NOT expose this to the LLM.
+   */
+  capabilities?: CapabilityLabel[];
   execute(args: Record<string, unknown>): Promise<string>;
   /**
    * Optional streaming entry point. Implementers MUST re-run the same


### PR DESCRIPTION
PR 2 from §10 of [docs/personal-agent-infrastructure.md](https://github.com/Ascendral/codebot-ai/blob/main/docs/personal-agent-infrastructure.md). **Boring on purpose.**

## Summary

Pure type addition. No behavior change. No new gating. No model sees the new field.

- `src/types.ts` — new `CapabilityLabel` union (11 labels per §7) + new optional `capabilities?: CapabilityLabel[]` field on `Tool`.
- `docs/personal-agent-infrastructure.md` — §5/§7/§10 amended per §13 doc-rot rule (runtime layer shape changed → doc must change in same PR).

## What changes

**`src/types.ts`** (~30 lines added):

```ts
export type CapabilityLabel =
  | 'read-only'
  | 'write-fs'
  | 'run-cmd'
  | 'browser-read'
  | 'browser-write'
  | 'net-fetch'
  | 'account-access'
  | 'send-on-behalf'   // always-ask (§7)
  | 'delete-data'      // always-ask (§7)
  | 'spend-money'      // always-ask + preview required (§7)
  | 'move-money';      // PROHIBITED — tools/connectors with this label must not be usable (§7)

export interface Tool {
  // ...existing fields unchanged...
  capabilities?: CapabilityLabel[];   // NEW, optional
  // ...
}
```

**`move-money` comment phrasing**: per Alex's review, intentionally framed as "tools/connectors with this label must not be usable" rather than naming a specific check site. Leaves the implementation free to enforce at registration, policy load, or gate time when PR 4 lands.

## Doc-rot rule applied

Per §13: any PR changing runtime layer shape must update the doc in the same change. This PR adds a field to the `Tool` interface (a §5 runtime-layer surface) and the slot mentioned in §7. So:

- §5 runtime diagram: "Tools (**35** today)" → "Tools (**36** today)" (corrects a stale-on-arrival count from PR #24 — the actual `ToolRegistry` registers 36).
- §10 PR 3 description: "existing **35** tools" → "existing **36** tools".
- §7 migration-path note: rewritten from "Labels do not yet exist on the `Tool` interface" to reflect that the slot now does exist after this PR.
- Last-updated stamp bumped.

## Out of scope (deliberate)

- **No tool gets labels populated yet.** That's PR 3, mechanical, separate review.
- **No code reads `capabilities`.** That's PR 4, where gating actually starts.
- **`ToolSchema` (model-facing) does NOT include `capabilities`.** Visibility-to-LLM is a behavior change for a later PR if/when we want it.
- **No new tests.** Pure type addition. `tsc` validates the union at compile time. Existing 16+ tests that `assert.strictEqual(tool.name, ...)` / `tool.permission` / `tool.cacheable` continue to pass because the new field is optional.

## Verification

- [x] `npm run build` → clean tsc
- [x] `node --test dist/tools/tools.test.js` → 73/73 pass
- [x] All recent security suites (test-runner, graphics, ssh-remote, database, docker, package-manager, symbol-indexer, vault-endpoint, find-symbol) → **212/212 pass** (no regression on prior security rows or Issues #11/#17)
- [x] `npx eslint src/types.ts` → 0 warnings, 0 errors
- [ ] CI matrix Linux/macOS/Windows × Node 18/20/22 — full green expected, same standard as PRs #19/#20/#21/#22.

## Notes

This is the first real test of the §13 doc-rot rule. It caught a tool-count drift (35 → 36) on the very first follow-up PR. That's the rule working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)