### PR TITLE
[INFRA] PR 3: Declare capability labels on all 36 tools + CI coverage enforcement

### DIFF
--- a/docs/personal-agent-infrastructure.md
+++ b/docs/personal-agent-infrastructure.md
@@ -264,7 +264,7 @@ The doc itself does not change behavior. The execution order to actually build t
 
 1. **PR 1 — this doc.** Architecture commitment, no code change. ← *this PR*
 2. **PR 2 — capability labels on `Tool` interface (metadata only).** Adds optional `capabilities?: CapabilityLabel[]` to `Tool`. Existing tools keep working with no labels declared. No gate change. Pure type addition. ~50 lines.
-3. **PR 3 — declare capability labels on existing 36 tools.** Mechanical. Each tool gets its label list. No behavior change. Reviewable in one sitting because it's a table.
+3. **PR 3 — declare capability labels on existing 36 tools.** ✓ Landed in PR #26. Each tool declares `capabilities: CapabilityLabel[]` on its class. No behavior change yet — labels are still inert metadata. Mixed-action tools (database, git, docker, package_manager, test_runner, app, etc.) carry the strict union of all action-level needs, with action-level granularity explicitly deferred. CI introspection at `src/tools/capability-coverage.test.ts` enforces 100% coverage going forward.
 4. **PR 4 — agent loop reads capabilities, escalates `permission` to `always-ask` when label demands it.** This is where capability labels start gating. Tests pin which (tool, action) combos require always-ask.
 5. **PR 5 — model router skeleton.** Pure decision-table function `pickModel(taskClass, sensitivity, budgetRemaining)`. Consumed by the agent loop. Replaces the current single-model selection.
 6. **PR 6 — budget controls.** Per-session cap, escalation logging, summarize-on-overflow. Wired into the router.
@@ -296,7 +296,7 @@ Per the anti-theater protocol: no measurement = no claim. Each architectural com
 |---|---|---|
 | **Audit-chain integrity** | CI step that reads `~/.codebot/audit/audit-*.jsonl` and verifies the hash chain end-to-end on every test session | Must pass on every CI run. A broken chain is a release blocker. |
 | **Tool calls without an audit entry** | Test harness counter: every `tool.execute()` call must produce an audit row | **Must be zero.** Off-the-record actions are a non-goal (§2). |
-| **% of registered tools with capability labels** | `ToolRegistry` introspection in CI | Reaches 100% by end of PR 3. Stays at 100% (S4 + the doc-rot rule below). |
+| **% of registered tools with capability labels** | `ToolRegistry` introspection in CI (`src/tools/capability-coverage.test.ts`) | **100% — enforced in CI as of PR 3** (PR #26). Test fails the build if any tool's `capabilities` is missing, empty, contains an unknown label, contains the PROHIBITED `move-money` label, or has duplicates. Stays at 100% (S4 + the §13 doc-rot rule). |
 | **Model-router cost per session** | Token-tracker rollup, written to a session summary | Tracked from PR 5 onward. Cheap-first heuristic should drive the median session below the pre-router single-model baseline. |
 | **Approval latency (always-ask actions)** | Time between the gate firing and the user's yes/no | Tracked from PR 4. If P95 latency is so high the user starts answering "yes" reflexively, the UX is broken — that's a metric, not an opinion. |
 | **Denied-action rate** | Audit-log filter for `capability_block` and `containment_reject` | Tracked from PR 4. A non-zero rate is healthy (the gate is doing work). A sudden spike or drop signals either a regression or an over-permissive change. |
@@ -323,4 +323,4 @@ This rule applies to this file, not the broader codebase. Other docs may rot at 
 
 ---
 
-*Last updated 2026-04-25 (PR 2 landed: `CapabilityLabel` union and optional `capabilities?` slot now live on `Tool` in `src/types.ts`; tool count corrected 35 → 36 to reflect actual `ToolRegistry` registration; §7 migration-path note updated to reflect that the slot exists). Earlier passes: 2026-04-25 split `move-money` (PROHIBITED) from `spend-money` (always-ask) and reframed Phase 2; 2026-04-24 engineering-contract discipline; 2026-04-24 user-owned multi-device-over-time vision. Against `main @ b8a5433` + this PR.*
+*Last updated 2026-04-25 (PR 3 landed: every registered tool now declares `capabilities: CapabilityLabel[]`; `src/tools/capability-coverage.test.ts` enforces 100% coverage in CI; §10 PR 3 marked done; §12 measurement signal flipped from "reaches 100% by PR 3" to "100% enforced in CI"). Earlier passes: 2026-04-25 PR 2 (CapabilityLabel union + slot); 2026-04-25 split `move-money` from `spend-money` and reframed Phase 2; 2026-04-24 engineering-contract discipline; 2026-04-24 user-owned multi-device-over-time vision. Against `main @ b43ff8a` + this PR.*

--- a/src/tools/app-connector.ts
+++ b/src/tools/app-connector.ts
@@ -8,7 +8,7 @@
  *   app github.create_issue { ... } → dispatch to connector action
  */
 
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { ConnectorRegistry } from '../connectors/registry';
 import { VaultManager } from '../vault';
 
@@ -16,6 +16,7 @@ export class AppConnectorTool implements Tool {
   name = 'app';
   description = 'Connect to external apps (GitHub, Slack, Jira, Linear). Use "list" to see available apps, "connect <app>" to set up, or "<app>.<action>" to execute (e.g., github.create_issue, slack.post_message, jira.search, linear.list_teams).';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['read-only', 'write-fs', 'net-fetch', 'account-access', 'send-on-behalf', 'delete-data'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/batch-edit.ts
+++ b/src/tools/batch-edit.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { isPathSafe } from '../security';
 import { checkSecretsForWrite } from '../secret-guard';
 import { PolicyEnforcer } from '../policy';
@@ -15,6 +15,7 @@ export class BatchEditTool implements Tool {
   name = 'batch_edit';
   description = 'Apply multiple find-and-replace edits across one or more files atomically. All edits are validated before any are applied. Useful for renaming, refactoring, and coordinated multi-file changes.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['write-fs'];
   private projectRoot: string;
   private policyEnforcer?: PolicyEnforcer;
 

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -1,4 +1,4 @@
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { PolicyEnforcer } from '../policy';
 import {
   BrowserSession,
@@ -36,6 +36,7 @@ export class BrowserTool implements Tool {
   name = 'browser';
   description = 'Control a web browser. Navigate to URLs, read page content, click elements, type text, scroll, press keys, find elements by text, hover, manage tabs, run JavaScript, and take screenshots. Use for web browsing, social media, email, research, testing, and automation.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['browser-read', 'browser-write', 'net-fetch'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/capability-coverage.test.ts
+++ b/src/tools/capability-coverage.test.ts
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { ToolRegistry } from './index';
+import type { CapabilityLabel } from '../types';
+
+/**
+ * PR 3 introspection test — capability label coverage.
+ *
+ * Per §12 of `docs/personal-agent-infrastructure.md`:
+ *   "% of registered tools with capability labels — Reaches 100% by
+ *    end of PR 3. Stays at 100% (S4 + the doc-rot rule)."
+ *
+ * This test enforces the 100% bar in CI. Any new tool added to
+ * `ToolRegistry` without `capabilities = [...]` declared on its class
+ * fails the build. Mechanical guardrail; the labels themselves are
+ * mechanically reviewed at PR time, but absence is automated.
+ *
+ * It also pins the union of valid labels so a typo (`'send-on-behalv'`)
+ * fails loudly instead of silently slipping through `as` casts.
+ */
+
+const VALID_LABELS: ReadonlyArray<CapabilityLabel> = [
+  'read-only',
+  'write-fs',
+  'run-cmd',
+  'browser-read',
+  'browser-write',
+  'net-fetch',
+  'account-access',
+  'send-on-behalf',
+  'delete-data',
+  'spend-money',
+  'move-money',
+];
+
+describe('ToolRegistry — capability label coverage (PR 3 enforcement)', () => {
+  // Use a default-constructed registry so the same set of tools that
+  // run in production is exercised here. AppConnectorTool may be
+  // absent if vault init fails on the test host; that's fine — we
+  // assert against whatever IS registered.
+  const registry = new ToolRegistry();
+  const tools = registry.all();
+
+  it('registers a non-zero number of tools', () => {
+    assert.ok(tools.length > 0, 'expected ToolRegistry to contain tools');
+  });
+
+  it('every registered tool declares a non-empty capabilities array', () => {
+    const missing: string[] = [];
+    const empty: string[] = [];
+    for (const t of tools) {
+      if (t.capabilities === undefined) { missing.push(t.name); continue; }
+      if (!Array.isArray(t.capabilities)) {
+        missing.push(`${t.name} (capabilities is not an array)`);
+        continue;
+      }
+      if (t.capabilities.length === 0) { empty.push(t.name); continue; }
+    }
+    assert.deepStrictEqual(missing, [],
+      `tools missing capabilities: ${missing.join(', ')}`);
+    assert.deepStrictEqual(empty, [],
+      `tools with empty capabilities (use the union of action-level needs, never []): ${empty.join(', ')}`);
+  });
+
+  it('every declared label is a valid CapabilityLabel from the §7 union', () => {
+    const validSet = new Set<string>(VALID_LABELS);
+    const violations: Array<{ tool: string; label: string }> = [];
+    for (const t of tools) {
+      if (!t.capabilities) continue;
+      for (const label of t.capabilities) {
+        if (!validSet.has(label)) {
+          violations.push({ tool: t.name, label });
+        }
+      }
+    }
+    assert.deepStrictEqual(violations, [],
+      `unknown labels declared: ${JSON.stringify(violations)}. Valid set: ${VALID_LABELS.join(', ')}`);
+  });
+
+  it('no tool declares the move-money label (PROHIBITED per §2/§7)', () => {
+    // PR 3 invariant: tools with move-money cannot exist/register.
+    // This test pins that. PR 4 will additionally enforce it at the
+    // gate level (rejecting any registered tool that carries it).
+    const offenders = tools
+      .filter(t => t.capabilities?.includes('move-money'))
+      .map(t => t.name);
+    assert.deepStrictEqual(offenders, [],
+      `tools declaring PROHIBITED label "move-money": ${offenders.join(', ')}. Per §2, move-money tools must not exist.`);
+  });
+
+  it('capabilities array contains no duplicates', () => {
+    const dupes: Array<{ tool: string; label: string }> = [];
+    for (const t of tools) {
+      if (!t.capabilities) continue;
+      const seen = new Set<string>();
+      for (const label of t.capabilities) {
+        if (seen.has(label)) {
+          dupes.push({ tool: t.name, label });
+        }
+        seen.add(label);
+      }
+    }
+    assert.deepStrictEqual(dupes, [],
+      `duplicate labels: ${JSON.stringify(dupes)}`);
+  });
+});

--- a/src/tools/code-analysis.ts
+++ b/src/tools/code-analysis.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 export class CodeAnalysisTool implements Tool {
   name = 'code_analysis';
   description = 'Analyze code structure. Actions: symbols (list classes/functions/exports), imports (list imports), outline (file structure), references (find where a symbol is used).';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   cacheable = true;
   parameters = {
     type: 'object',

--- a/src/tools/code-review.ts
+++ b/src/tools/code-review.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 interface Issue {
   file: string;
@@ -27,6 +27,7 @@ export class CodeReviewTool implements Tool {
   name = 'code_review';
   description = 'Review code for security issues, complexity, and code smells. Actions: security, complexity, review (full).';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   cacheable = true;
   parameters = {
     type: 'object',

--- a/src/tools/database.ts
+++ b/src/tools/database.ts
@@ -34,7 +34,7 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 const BLOCKED_SQL = [
   /\bDROP\s+(TABLE|DATABASE|INDEX|VIEW)\b/i,
@@ -66,6 +66,7 @@ export class DatabaseTool implements Tool {
   name = 'database';
   description = 'Query SQLite databases. Actions: query, tables, schema, info. Blocks DROP/DELETE/TRUNCATE for safety.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['read-only', 'write-fs', 'run-cmd'];
   /**
    * Containment root. Issue #17 pattern: plumbed from `Agent.projectRoot`
    * via `ToolRegistry`, falls back to `process.cwd()` for back-compat.

--- a/src/tools/decompose-goal.ts
+++ b/src/tools/decompose-goal.ts
@@ -11,7 +11,7 @@
  *   - next: Get the next ready subtask(s)
  */
 
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { GoalDecomposer, GoalTree, SubtaskDraft } from '../goal-decomposer';
 
 export class DecomposeGoalTool implements Tool {
@@ -20,6 +20,7 @@ export class DecomposeGoalTool implements Tool {
     'Autonomous goal decomposition: break high-level goals into dependency-ordered subtask trees, ' +
     'track progress, and get next ready tasks. Actions: decompose, status, complete, fail, add_subtasks, next.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/delegate.ts
+++ b/src/tools/delegate.ts
@@ -4,13 +4,14 @@
  * Allows the parent agent to spawn child agents for parallel work.
  */
 
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { Orchestrator, AgentTask, AgentResult, generateTaskId } from '../orchestrator';
 
 export class DelegateTool implements Tool {
   name = 'delegate';
   description = 'Spawn child agent(s) to handle subtasks.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['read-only', 'write-fs', 'run-cmd', 'browser-read', 'browser-write', 'net-fetch', 'account-access', 'send-on-behalf', 'delete-data', 'spend-money'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/diff-viewer.ts
+++ b/src/tools/diff-viewer.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
 import { execSync } from 'child_process';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 export class DiffViewerTool implements Tool {
   name = 'diff_viewer';
   description = 'View diffs. Actions: files (compare two files), git_diff (working tree changes), staged (staged changes), commit (show a commit diff).';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only', 'run-cmd'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/docker.ts
+++ b/src/tools/docker.ts
@@ -31,7 +31,7 @@
 
 import { execFileSync } from 'child_process';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 const ALLOWED_ACTIONS = [
   'ps', 'images', 'run', 'stop', 'rm', 'build', 'logs', 'exec',
@@ -110,6 +110,7 @@ export class DockerTool implements Tool {
   name = 'docker';
   description = 'Run Docker operations. Actions: ps, images, run, stop, rm, build, logs, exec, compose_up, compose_down, compose_ps, inspect, pull. `args` MUST be a string array (e.g., ["-d", "--name", "nginx", "nginx:latest"]). String args are rejected.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['write-fs', 'run-cmd', 'net-fetch'];
   /**
    * Containment root. Issue #17 pattern: plumbed from `Agent.projectRoot`
    * via `ToolRegistry`, falls back to `process.cwd()` for back-compat.

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { isPathSafe } from '../security';
 import { checkSecretsForWrite } from '../secret-guard';
 import { PolicyEnforcer } from '../policy';
@@ -15,6 +15,7 @@ export class EditFileTool implements Tool {
   name = 'edit_file';
   description = 'Edit a file by replacing an exact string match with new content. The old_string must appear exactly once in the file. Shows a diff preview and creates an undo snapshot.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['write-fs'];
   private projectRoot: string;
   private policyEnforcer?: PolicyEnforcer;
 

--- a/src/tools/execute.ts
+++ b/src/tools/execute.ts
@@ -1,5 +1,5 @@
 import { execSync, spawn } from 'child_process';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { isCwdSafe } from '../security';
 import { sandboxExec, isDockerAvailable } from '../sandbox';
 import { PolicyEnforcer } from '../policy';
@@ -154,6 +154,7 @@ export class ExecuteTool implements Tool {
   constructor(projectRoot?: string) { this.projectRoot = projectRoot || process.cwd(); }
   description = 'Execute a shell command. Returns stdout and stderr. Use for running tests, builds, git commands, etc.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['read-only', 'write-fs', 'run-cmd'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/find-symbol.ts
+++ b/src/tools/find-symbol.ts
@@ -13,7 +13,7 @@
  * this.
  */
 
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { SymbolIndexer, SymbolEntry } from '../symbol-indexer';
 
 export class FindSymbolTool implements Tool {
@@ -26,6 +26,7 @@ export class FindSymbolTool implements Tool {
     'Indexes Python, TypeScript, JavaScript, Go, Rust, Ruby, Java. Use this as ' +
     'the FIRST STEP when you need to navigate a codebase to find where to edit.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   cacheable = true;
 
   parameters = {

--- a/src/tools/git.ts
+++ b/src/tools/git.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { PolicyEnforcer } from '../policy';
 
 const ALLOWED_ACTIONS = [
@@ -36,6 +36,7 @@ export class GitTool implements Tool {
   name = 'git';
   description = 'Run git operations. Actions: status, diff, log, commit, branch, checkout, stash, push, pull, merge, blame, tag, add, reset, clone.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['write-fs', 'run-cmd', 'net-fetch'];
   private policyEnforcer?: PolicyEnforcer;
   parameters = {
     type: 'object',

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 export class GlobTool implements Tool {
   name = 'glob';
@@ -8,6 +8,7 @@ export class GlobTool implements Tool {
   constructor(projectRoot?: string) { this.projectRoot = projectRoot || process.cwd(); }
   description = 'Find files matching a glob pattern. Returns matching file paths relative to the search directory.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   cacheable = true;
   parameters = {
     type: 'object',

--- a/src/tools/graphics.ts
+++ b/src/tools/graphics.ts
@@ -44,7 +44,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { execFileSync } from 'child_process';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 // ─── Containment ────────────────────────────────────────────────────────────
 
@@ -255,6 +255,7 @@ export class GraphicsTool implements Tool {
   name = 'graphics';
   description = 'Image processing, SVG generation & design assets. Actions: resize, convert, compress, crop, watermark, info, svg, favicon, og_image, combine. Uses ImageMagick/sips.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['write-fs', 'run-cmd'];
   /**
    * Containment root. Issue #17: plumbed from `Agent.projectRoot` via
    * `ToolRegistry`. Pre-fix every method gated against `process.cwd()`.

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 export class GrepTool implements Tool {
   name = 'grep';
@@ -8,6 +8,7 @@ export class GrepTool implements Tool {
   constructor(projectRoot?: string) { this.projectRoot = projectRoot || process.cwd(); }
   description = 'Search file contents for a regex pattern. Returns matching lines with file paths and line numbers.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   cacheable = true;
   parameters = {
     type: 'object',

--- a/src/tools/http-client.ts
+++ b/src/tools/http-client.ts
@@ -1,10 +1,11 @@
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { validateOutboundUrl } from '../net-guard';
 
 export class HttpClientTool implements Tool {
   name = 'http_client';
   description = 'Make HTTP requests. Supports GET, POST, PUT, DELETE, PATCH with headers, auth, and body.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['read-only', 'net-fetch'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/image-info.ts
+++ b/src/tools/image-info.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 export class ImageInfoTool implements Tool {
   name = 'image_info';
   description = 'Get image file information — dimensions, format, file size. Supports PNG, JPEG, GIF, BMP, SVG.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   cacheable = true;
   parameters = {
     type: 'object',

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -1,10 +1,11 @@
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { MemoryManager } from '../memory';
 
 export class MemoryTool implements Tool {
   name = 'memory';
   description = 'Read or write persistent memory. Memory survives across sessions and is always available to you. Use this to remember important context, user preferences, project patterns, or anything worth keeping.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['write-fs'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/multi-search.ts
+++ b/src/tools/multi-search.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 interface SearchResult {
   file: string;
@@ -14,6 +14,7 @@ export class MultiSearchTool implements Tool {
   name = 'multi_search';
   description = 'Fuzzy search across filenames, file contents, and code symbols. Returns ranked results by relevance.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/notification.ts
+++ b/src/tools/notification.ts
@@ -1,9 +1,10 @@
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 export class NotificationTool implements Tool {
   name = 'notification';
   description = 'Send notifications via webhook (Slack, Discord, or generic). Actions: slack, discord, webhook.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['net-fetch', 'send-on-behalf'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/package-manager.ts
+++ b/src/tools/package-manager.ts
@@ -26,7 +26,7 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 interface PkgManager {
   name: string;
@@ -140,6 +140,7 @@ export class PackageManagerTool implements Tool {
   name = 'package_manager';
   description = 'Manage dependencies. Auto-detects npm/yarn/pnpm/pip/cargo/go. Actions: install, add, remove, list, outdated, audit, detect.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['write-fs', 'run-cmd', 'net-fetch'];
   /**
    * Containment root. Issue #17 pattern: plumbed from `Agent.projectRoot`
    * via `ToolRegistry`, falls back to `process.cwd()` for back-compat.

--- a/src/tools/pdf-extract.ts
+++ b/src/tools/pdf-extract.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 export class PdfExtractTool implements Tool {
   name = 'pdf_extract';
   description = 'Extract text and metadata from PDF files. Actions: text, info, pages.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/plugin-forge.ts
+++ b/src/tools/plugin-forge.ts
@@ -15,7 +15,7 @@ import * as path from 'path';
 import * as crypto from 'crypto';
 import { codebotPath } from '../paths';
 import { isPluginSafe } from '../plugins';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 // ── Types ──
 
@@ -44,6 +44,7 @@ export class PluginForgeTool implements Tool {
   name = 'plugin_forge';
   description = 'Create, validate, and install self-authored plugins. Actions: create (write and validate a plugin), list (show installed plugins), validate (check a plugin for safety), promote (move from staging to active), remove (delete a plugin).';
   permission: 'prompt' = 'prompt';
+  capabilities: CapabilityLabel[] = ['write-fs'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 export class ReadFileTool implements Tool {
   name = 'read_file';
   description = 'Read the contents of a file. Returns file content with line numbers.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   cacheable = true;
   private projectRoot: string;
   constructor(projectRoot?: string) { this.projectRoot = projectRoot || process.cwd(); }

--- a/src/tools/research.ts
+++ b/src/tools/research.ts
@@ -6,7 +6,7 @@
  * Designed to be used by the agent as a single tool call for thorough research.
  */
 
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 const TIMEOUT = 30_000;
 const MAX_SOURCES = 8;
@@ -118,6 +118,7 @@ export class DeepResearchTool implements Tool {
   name = 'deep_research';
   description = 'Perform deep research on a topic. Searches the web, fetches multiple sources, and compiles a structured report with key findings and source URLs. Use this when you need thorough, multi-source research on any topic.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only', 'net-fetch'];
   cacheable = true;
 
   parameters = {

--- a/src/tools/routine.ts
+++ b/src/tools/routine.ts
@@ -1,4 +1,4 @@
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import * as fs from 'fs';
 import * as path from 'path';
 import { codebotPath } from '../paths';
@@ -21,6 +21,7 @@ export class RoutineTool implements Tool {
   name = 'routine';
   description = 'Manage scheduled routines (recurring tasks). Add daily social media posts, email checks, research tasks, etc. Uses cron expressions for scheduling (e.g., "0 9 * * *" for 9am daily, "0 */6 * * *" for every 6 hours, "30 18 * * 1-5" for 6:30pm weekdays).';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['write-fs'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/skill-forge.ts
+++ b/src/tools/skill-forge.ts
@@ -15,7 +15,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { codebotPath } from '../paths';
 
 interface ForgedSkill {
@@ -123,6 +123,7 @@ export class SkillForgeTool implements Tool {
   name = 'skill_forge';
   description = 'Create, list, reinforce, or delete reusable multi-step skills. Skills compose existing tools into higher-level workflows that persist across sessions. Both CodeBot and CodeAGI can author and consume skills from the shared store.';
   permission: 'prompt' = 'prompt';
+  capabilities: CapabilityLabel[] = ['write-fs'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/ssh-remote.ts
+++ b/src/tools/ssh-remote.ts
@@ -39,7 +39,7 @@
 
 import { execFileSync } from 'child_process';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 // Block injection-y characters in host/user inputs. Even argv-only execs
 // pipe `host` to OpenSSH's config parser, where ProxyCommand and similar
@@ -69,6 +69,7 @@ export class SshRemoteTool implements Tool {
   name = 'ssh_remote';
   description = 'Execute commands on remote servers via SSH, or upload/download files via SCP. Actions: exec, upload, download.';
   permission: Tool['permission'] = 'always-ask';
+  capabilities: CapabilityLabel[] = ['write-fs', 'run-cmd', 'net-fetch'];
   /**
    * Containment root for local paths (upload source, download target).
    * Issue #17 pattern: plumbed from `Agent.projectRoot` via `ToolRegistry`,

--- a/src/tools/task-planner.ts
+++ b/src/tools/task-planner.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 interface Task {
   id: number;
@@ -18,6 +18,7 @@ export class TaskPlannerTool implements Tool {
   name = 'task_planner';
   description = 'Plan and track tasks. Actions: add, list, update, complete, remove, clear.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['write-fs'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 /**
  * Framework descriptor. `command` + `args` are executed via execFileSync
@@ -38,6 +38,7 @@ export class TestRunnerTool implements Tool {
   name = 'test_runner';
   description = 'Run tests with auto-detected framework. Actions: run (execute tests), detect (show detected framework), list (list test files).';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['read-only', 'write-fs', 'run-cmd'];
   /**
    * Containment root. Issue #17: was `process.cwd()` baked in via Row 10;
    * now plumbed from `Agent.projectRoot` via `ToolRegistry` so a permission-

--- a/src/tools/think.ts
+++ b/src/tools/think.ts
@@ -1,9 +1,10 @@
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 
 export class ThinkTool implements Tool {
   name = 'think';
   description = 'A reasoning scratchpad. Use to plan your approach, analyze code, or work through complex problems before taking action. No side effects.';
   permission: Tool['permission'] = 'auto';
+  capabilities: CapabilityLabel[] = ['read-only'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/web-fetch.ts
+++ b/src/tools/web-fetch.ts
@@ -1,4 +1,4 @@
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { cacheGet, cacheSet } from '../offline-cache';
 import { validateOutboundUrl } from '../net-guard';
 
@@ -6,6 +6,7 @@ export class WebFetchTool implements Tool {
   name = 'web_fetch';
   description = 'Make HTTP requests to URLs or APIs. Fetch web pages, call REST APIs, post data. Supports GET, POST, PUT, PATCH, DELETE.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['read-only', 'net-fetch'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -1,4 +1,4 @@
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { cacheGet, cacheSet } from '../offline-cache';
 
 interface SearchResult {
@@ -11,6 +11,7 @@ export class WebSearchTool implements Tool {
   name = 'web_search';
   description = 'Search the web using DuckDuckGo. Returns titles, URLs, and snippets. Use for research, fact-checking, finding documentation, or discovering information. If results are empty, try the browser tool to navigate to a search engine directly.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['read-only', 'net-fetch'];
   parameters = {
     type: 'object',
     properties: {

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool } from '../types';
+import { Tool, CapabilityLabel } from '../types';
 import { isPathSafe } from '../security';
 import { checkSecretsForWrite } from '../secret-guard';
 import { PolicyEnforcer } from '../policy';
@@ -12,6 +12,7 @@ export class WriteFileTool implements Tool {
   name = 'write_file';
   description = 'Create a new file or overwrite an existing file with the given content. Automatically saves an undo snapshot for existing files.';
   permission: Tool['permission'] = 'prompt';
+  capabilities: CapabilityLabel[] = ['write-fs'];
   private projectRoot: string;
   private policyEnforcer?: PolicyEnforcer;
 


### PR DESCRIPTION
PR 3 from §10 of [docs/personal-agent-infrastructure.md](https://github.com/Ascendral/codebot-ai/blob/main/docs/personal-agent-infrastructure.md). **Mechanical pass. No behavior change yet.**

Each registered tool now declares `capabilities: CapabilityLabel[]` on its class. PR 4 will wire the agent loop to gate on these. PR 3 just populates the slot and locks in CI enforcement.

## Approach

Per the read-first review's "don't silently under-label mixed tools" rule: tools with mixed-action surfaces (read AND write, or local AND external) carry the **strict union** of all action-level needs. Action-level granularity is explicitly deferred to a later RFC.

## Label assignments (36 tools)

**read-only only** (11):
read_file, glob, grep, find_symbol, multi_search, code_analysis, code_review, image_info, pdf_extract, think, decompose_goal

**write-fs only** (8):
write_file, edit_file, batch_edit, memory, task_planner, routine, skill_forge, **plugin_forge**

> `plugin_forge` was specifically asked about. **Verified not to shell out** — file docstring line 6: "Hardcoded blocklist (no child_process, no eval, no fs, no net)." Label is `write-fs` only.

**read-only + run-cmd** (1):
diff_viewer (execSync git for read views)

**read-only + write-fs + run-cmd** (3):
execute, test_runner, database (mixed SQL)

**write-fs + run-cmd + net-fetch** (4):
git, package_manager, docker, ssh_remote (strict union — push/pull, registry, remote)

**browser-read + browser-write + net-fetch** (1):
browser (no `account-access` at raw browser-tool level per review)

**read-only + net-fetch** (4):
web_fetch, web_search, **http_client**, deep_research

> `http_client` carries `read-only + net-fetch` only. **NOT** `write-fs`. **NOT** `send-on-behalf`. Arbitrary HTTP mutation (POST/PUT/DELETE) doesn't fit cleanly under any current label and needs action-level labels later. Flagged here, deferred.

**net-fetch + send-on-behalf** (1):
notification (Slack/Discord webhooks)

**write-fs + run-cmd** (1):
graphics (ImageMagick/sips subprocess)

**Strict-union mixed (2)**:
- `app`: `read-only, write-fs, net-fetch, account-access, send-on-behalf, delete-data` — covers 11 connectors (Gmail/GitHub/Slack/Jira/Linear/Notion/GCal/GDrive/X/OpenAIImages/Replicate). Strictest set across all verbs of all connectors. Per-connector split deferred to a separate refactor.
- `delegate`: `read-only, write-fs, run-cmd, browser-read, browser-write, net-fetch, account-access, send-on-behalf, delete-data, spend-money`. delegate spawns child agents that can call any other tool; under-labeling would be dishonest. **`move-money` DELIBERATELY EXCLUDED** per the §7 rule "prohibited tools must not exist."

## CI enforcement

New test: `src/tools/capability-coverage.test.ts` (5 tests):
1. `ToolRegistry` registers a non-zero number of tools
2. Every registered tool declares a non-empty `capabilities` array
3. Every label is a valid `CapabilityLabel` from the §7 union (catches typos like `'send-on-behalv'`)
4. No tool declares the PROHIBITED `move-money` label
5. No duplicate labels within a single tool

§12 of the architecture doc updated: "% of registered tools with capability labels" → **100%, enforced in CI as of PR 3**.

## Doc-rot rule applied (§13)

- **§10 PR 3** marked landed with a note about strict union + deferred action-level granularity.
- **§12 measurement** flipped from "reaches 100% by end of PR 3" to "100% enforced in CI as of PR 3" with a pointer to the test file.
- Last-updated stamp bumped.

## Verification

- [x] `npm run build` → clean tsc
- [x] `node --test dist/tools/capability-coverage.test.js` → **5/5 pass**
- [x] `node --test dist/tools/tools.test.js` → 73/73 pass (no regression)
- [x] All recent security suites (test-runner, graphics, ssh-remote, database, docker, package-manager, symbol-indexer, vault-endpoint, find-symbol) → **212/212 pass**
- [x] `npx eslint` on the new test file → 0 warnings, 0 errors
- [x] 36 tool source files modified (1–10 lines each: import update + capabilities field declaration)
- [ ] CI matrix Linux/macOS/Windows × Node 18/20/22 — full green expected, same standard as PRs #19/#20/#21/#22/#25.

## Out of scope (deliberate)

- **No code reads `capabilities` for behavior.** PR 4 wires gating.
- **`ToolSchema` (model-facing) does NOT include the field.** Visibility to LLM is a separate later decision.
- **No action-level labels** (`Tool.actionCapabilities` map). Strict union is the correct temporary posture.
- **No per-connector split** of `AppConnectorTool`. Strict union treats it as one tool.
- **No PROHIBITED-registration-time check on `move-money`.** PR 4 lands that. PR 3 only asserts via the new test that no tool declares it today.

## Open question for PR 4

The `delegate` tool's strict label union (10 labels) means PR 4 will likely escalate it to `always-ask` for almost everything. That might be the right answer — delegate is an inherently dangerous meta-tool — but worth flagging now so the gating-design PR doesn't surprise anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)